### PR TITLE
In 14 youtube analytics oauth 연동 analytics 인증용 별도 플로우 

### DIFF
--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -1,4 +1,37 @@
 package com.example.inflace.domain.video.controller;
 
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoResponse;
+import com.example.inflace.domain.video.service.VideoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/video")
 public class VideoController {
+
+    private final VideoService videoService;
+
+    // TODO : 포스트맨 test용 예시 컨트롤러. 차후 기능 개발 용으로는 API DTO 따로 짜서 연동 계획입니다!!
+//    @GetMapping("/analytics")
+//    public YoutubeAnalyticsVideoResponse getAnalytics(
+//            @RequestParam String startDate,
+//            @RequestParam String endDate,
+//            @RequestParam List<String> metrics
+//    ) {
+//        return videoService.getYoutubeAnalyticsVideo(
+//                new YoutubeAnalyticsVideoRequest(
+//                        LocalDate.parse(startDate),
+//                        LocalDate.parse(endDate),
+//                        metrics
+//                )
+//        );
+//    }
 }

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -1,0 +1,4 @@
+package com.example.inflace.domain.video.controller;
+
+public class VideoController {
+}

--- a/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
@@ -1,0 +1,4 @@
+package com.example.inflace.domain.video.dto;
+
+public record YoutubeAnalyticsVideoRequest() {
+}

--- a/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
@@ -1,4 +1,14 @@
 package com.example.inflace.domain.video.dto;
 
-public record YoutubeAnalyticsVideoRequest() {
+import java.time.LocalDate;
+import java.util.List;
+
+public record YoutubeAnalyticsVideoRequest(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> metrics
+) {
+    public String formattedMetricsList() {
+        return String.join(",", metrics);
+    }
 }

--- a/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoResponse.java
@@ -1,4 +1,15 @@
 package com.example.inflace.domain.video.dto;
 
-public class YoutubeAnalyticsVideoResponse {
+import java.util.List;
+
+public record YoutubeAnalyticsVideoResponse(
+        String kind,
+        List<ColumnHeader> columnHeaders,
+        List<List<Object>> rows   // 타입 혼재, 차후 service에서 타입 맞춰서 파싱
+) {
+    public record ColumnHeader(
+            String name,
+            String dataType,
+            String columnType
+    ) {}
 }

--- a/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoResponse.java
@@ -1,0 +1,4 @@
+package com.example.inflace.domain.video.dto;
+
+public class YoutubeAnalyticsVideoResponse {
+}

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -1,0 +1,4 @@
+package com.example.inflace.domain.video.service;
+
+public class VideoService {
+}

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -1,4 +1,19 @@
 package com.example.inflace.domain.video.service;
 
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoResponse;
+import com.example.inflace.global.client.YoutubeAnalyticsApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class VideoService {
+
+    private final YoutubeAnalyticsApiClient youtubeAnalyticsApiClient;
+
+    private YoutubeAnalyticsVideoResponse getYoutubeAnalyticsVideo(YoutubeAnalyticsVideoRequest request) {
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(request);
+        return response;
+    }
 }

--- a/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
@@ -1,4 +1,42 @@
 package com.example.inflace.global.client;
 
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoResponse;
+import com.example.inflace.global.properties.YoutubeProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
 public class YoutubeAnalyticsApiClient {
+
+    private static final String ANALYTICS_PATH = "/reports";
+    private static final String CHANNEL_IDS = "channel==MINE";
+
+    private final RestClient restClient;
+    private final YoutubeProperties youtubeProperties;
+
+    public YoutubeAnalyticsVideoResponse getYoutubeAnalytics(YoutubeAnalyticsVideoRequest request) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(youtubeProperties.analyticsApi().baseUrl())
+                .path(ANALYTICS_PATH)
+                .queryParam("startDate", request.startDate().toString())
+                .queryParam("endDate", request.endDate().toString())
+                .queryParam("ids", CHANNEL_IDS)
+                .queryParam("metrics", request.formattedMetricsList())
+                .build()
+                .toUri();
+
+        // TODO : 차후 header에 access token 실어 보내는 방식으로 변경 예정
+        return restClient.get()
+                .uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + youtubeProperties.analyticsApi().accessToken())
+                .retrieve()
+                .body(YoutubeAnalyticsVideoResponse.class);
+    }
 }

--- a/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
@@ -1,0 +1,4 @@
+package com.example.inflace.global.client;
+
+public class YoutubeAnalyticsApiClient {
+}

--- a/src/main/java/com/example/inflace/global/properties/YoutubeProperties.java
+++ b/src/main/java/com/example/inflace/global/properties/YoutubeProperties.java
@@ -4,10 +4,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "youtube")
 public record YoutubeProperties(
-        DataApi dataApi
+        DataApi dataApi,
+        AnalyticsApi analyticsApi
 ) {
     public record DataApi(
             String baseUrl,
             String apiKey
+    ){}
+
+    public record AnalyticsApi(
+            String baseUrl,
+            String accessToken  // TODO : 임시, 차후 로그인 구현 시 OAuth2AuthorizedClientService에서 꺼내서 헤더에 주입
     ){}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   application:
     name: inflace
   datasource:
@@ -17,3 +19,6 @@ youtube:
   data-api:
     base-url: ${DATA_API_URL}
     api-key: ${DATA_API_KEY}
+  analytics-api:
+    base-url: ${ANALYTICS_API_URL}
+    accessToken: ${ANALYTICS_TEST_ACCESS_TOKEN}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,4 +21,4 @@ youtube:
     api-key: ${DATA_API_KEY}
   analytics-api:
     base-url: ${ANALYTICS_API_URL}
-    accessToken: ${ANALYTICS_TEST_ACCESS_TOKEN}
+    access-token: ${ANALYTICS_TEST_ACCESS_TOKEN}


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #13 

---

## comment
<!-- 남길 코멘트 -->

- analytics api 연동 완료하였습니다.
- 원래는 사용자의 accessToken 을 사용해야하는데 현재는 구글 플레이그라운드의 임시 발급 테스트 토큰을 활용하였습니다. 
  - 향후 로그인 구현 시 이 부분은 아주 약간의 변경 있을 예정이고, TODO 주석 처리해두었습니다.
- 원래 env를 읽으려면 IDE에 설정을 해야 하는데, IDE에 의존하지 않고 코드레벨에서 해결하기 위해 yaml 파일에 config 주입 설정을 해두었습니다. 
  - 프로젝트 루트에 .env 만들면 자동으로 주입합니다.
  - 이 부분은 설정을 추가한거라 피드백 받고 싶습니다!

<img width="346" height="188" alt="image" src="https://github.com/user-attachments/assets/dfc238ca-4a19-4a44-b827-b8ad509853ab" />

- 현재 test 토큰이라 자세한 결과는 없고, columnHeaders는 정상적으로 출력됩니다.