### PR TITLE
feat: oauth 구글 로그인 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
@@ -1,0 +1,22 @@
+package com.example.inflace.domain.auth.application;
+
+import com.example.inflace.domain.auth.presentation.dto.GoogleTokenResponse;
+import com.example.inflace.domain.auth.presentation.dto.GoogleUserInfoResponse;
+import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
+import com.example.inflace.global.client.GoogleApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("google")
+@RequiredArgsConstructor
+public class GoogleLoginStrategy implements OAuthLoginStrategy {
+
+    private final GoogleApiClient googleApiClient;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String code) {
+        GoogleTokenResponse token = googleApiClient.getToken(code);
+        GoogleUserInfoResponse userInfo = googleApiClient.getUserInfo(token.accessToken());
+        return new OAuthUserInfo(userInfo.name(), userInfo.email(), userInfo.picture());
+    }
+}

--- a/src/main/java/com/example/inflace/domain/auth/application/OAuthLoginStrategy.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/OAuthLoginStrategy.java
@@ -1,0 +1,8 @@
+package com.example.inflace.domain.auth.application;
+
+import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
+
+public interface OAuthLoginStrategy {
+
+    OAuthUserInfo getUserInfo(String code);
+}

--- a/src/main/java/com/example/inflace/domain/auth/application/OAuthStrategyRouter.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/OAuthStrategyRouter.java
@@ -1,0 +1,23 @@
+package com.example.inflace.domain.auth.application;
+
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthStrategyRouter {
+
+    private final Map<String, OAuthLoginStrategy> strategyMap;
+
+    public OAuthLoginStrategy getStrategy(String provider) {
+        OAuthLoginStrategy strategy = strategyMap.get(provider);
+        if (strategy == null) {
+            throw new ApiException(ErrorDefine.AUTH_UNSUPPORTED_PROVIDER);
+        }
+        return strategy;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/com/example/inflace/domain/auth/facade/AuthFacade.java
@@ -1,0 +1,29 @@
+package com.example.inflace.domain.auth.facade;
+
+import com.example.inflace.domain.auth.application.OAuthStrategyRouter;
+import com.example.inflace.domain.auth.presentation.dto.AuthResponse;
+import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
+import com.example.inflace.domain.user.application.UserService;
+import com.example.inflace.global.config.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthFacade {
+
+    private final OAuthStrategyRouter oAuthStrategyRouter;
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+
+    public AuthResponse login(String provider, String code) {
+        OAuthUserInfo userInfo = oAuthStrategyRouter.getStrategy(provider).getUserInfo(code);
+
+        userService.registerIfNotExists(userInfo.name(), userInfo.email(), userInfo.picture());
+
+        String accessToken = jwtProvider.createAccessToken(userInfo.email());
+        String refreshToken = jwtProvider.createRefreshToken(userInfo.email());
+
+        return new AuthResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/controller/AuthApi.java
@@ -1,0 +1,22 @@
+package com.example.inflace.domain.auth.presentation.controller;
+
+import com.example.inflace.domain.auth.presentation.dto.AuthResponse;
+import com.example.inflace.global.exception.ApiErrorDefines;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Auth", description = "사용자 인증 API")
+public interface AuthApi {
+
+    @Operation(
+            summary = "소셜 로그인",
+            description = "소셜 로그인 제공자(google 등)의 인가코드를 전달받아 " +
+                    "사용자를 인증하고, Access Token과 Refresh Token을 발급합니다."
+    )
+    @ApiErrorDefines(ErrorDefine.AUTH_UNSUPPORTED_PROVIDER)
+    BaseResponse<AuthResponse> login(@RequestParam("provider") String provider,
+                                     @RequestParam("code") String code);
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.example.inflace.domain.auth.presentation.controller;
+
+import com.example.inflace.domain.auth.facade.AuthFacade;
+import com.example.inflace.domain.auth.presentation.dto.AuthResponse;
+import com.example.inflace.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+
+    private final AuthFacade authFacade;
+
+    @Override
+    @GetMapping("/login")
+    public BaseResponse<AuthResponse> login(@RequestParam("provider") String provider,
+                                            @RequestParam("code") String code) {
+        AuthResponse response = authFacade.login(provider, code);
+        return new BaseResponse<>(response);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/dto/AuthResponse.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/dto/AuthResponse.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.auth.presentation.dto;
+
+public record AuthResponse(
+        String AccessToken,
+        String RefreshToken
+) {
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/dto/GoogleTokenResponse.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/dto/GoogleTokenResponse.java
@@ -1,0 +1,9 @@
+package com.example.inflace.domain.auth.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType
+) {
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/dto/GoogleUserInfoResponse.java
@@ -1,0 +1,8 @@
+package com.example.inflace.domain.auth.presentation.dto;
+
+public record GoogleUserInfoResponse(
+        String name,
+        String email,
+        String picture
+) {
+}

--- a/src/main/java/com/example/inflace/domain/auth/presentation/dto/OAuthUserInfo.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/dto/OAuthUserInfo.java
@@ -1,0 +1,8 @@
+package com.example.inflace.domain.auth.presentation.dto;
+
+public record OAuthUserInfo(
+        String name,
+        String email,
+        String picture
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -1,0 +1,18 @@
+package com.example.inflace.domain.user.application;
+
+import com.example.inflace.domain.user.infra.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerIfNotExists(String name, String email, String profileImage) {
+        userRepository.insertIfNotExists(name, email, profileImage);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/user/domain/Plan.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/Plan.java
@@ -1,0 +1,6 @@
+package com.example.inflace.domain.user.domain;
+
+public enum Plan {
+    FREE,
+    PRO
+}

--- a/src/main/java/com/example/inflace/domain/user/domain/User.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/User.java
@@ -1,0 +1,44 @@
+package com.example.inflace.domain.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String name;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Plan plan;
+
+    @Builder
+    public User(String name, String profileImage, String email, Plan plan) {
+        this.name = name;
+        this.profileImage = profileImage;
+        this.email = email;
+        this.plan = plan;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/user/infra/UserRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserRepository.java
@@ -1,0 +1,25 @@
+package com.example.inflace.domain.user.infra;
+
+import com.example.inflace.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 유저 존재 검증 및 회원가입 쿼리. 0이면 로그인, 1이면 신규 회원가입
+    @Modifying
+    @Query(nativeQuery = true, value = """                                                                                
+  insert into users (name, email, profile_image, plan)                                                                  
+  select :name, :email, :profileImage, 'FREE'                                                                           
+  where not exists (
+    select 1
+    from users
+    where email = :email
+)                                                           
+  """)
+    int insertIfNotExists(@Param("name") String name,
+                          @Param("email") String email,
+                          @Param("profileImage") String profileImage);
+}

--- a/src/main/java/com/example/inflace/global/client/GoogleApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/GoogleApiClient.java
@@ -1,0 +1,47 @@
+package com.example.inflace.global.client;
+
+import com.example.inflace.domain.auth.presentation.dto.GoogleTokenResponse;
+import com.example.inflace.domain.auth.presentation.dto.GoogleUserInfoResponse;
+import com.example.inflace.global.properties.GoogleProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleApiClient {
+
+    private static final String TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private static final String USER_INFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    private final RestClient restClient;
+    private final GoogleProperties googleProperties;
+
+    public GoogleTokenResponse getToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", googleProperties.clientId());
+        params.add("client_secret", googleProperties.clientSecret());
+        params.add("redirect_uri", googleProperties.redirectUri());
+        params.add("grant_type", "authorization_code");
+
+        return restClient.post()
+                .uri(TOKEN_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .body(GoogleTokenResponse.class);
+    }
+
+    public GoogleUserInfoResponse getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(USER_INFO_URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(GoogleUserInfoResponse.class);
+    }
+}

--- a/src/main/java/com/example/inflace/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/inflace/global/config/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.example.inflace.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.isValid(token)) {
+            String email = jwtProvider.getEmail(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(email, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/inflace/global/config/JwtProvider.java
+++ b/src/main/java/com/example/inflace/global/config/JwtProvider.java
@@ -1,0 +1,61 @@
+package com.example.inflace.global.config;
+
+import com.example.inflace.global.properties.JwtProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    public String createAccessToken(String email) {
+        return createToken(email, jwtProperties.expiration());
+    }
+
+    public String createRefreshToken(String email) {
+        return createToken(email, jwtProperties.expiration() * 24 * 14);
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean isValid(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String createToken(String email, long expiration) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/example/inflace/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/inflace/global/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package com.example.inflace.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/health-check",
+                                "/v3/api-docs/**",
+                                "/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorDefine {
 
     INVALID_HEADER_ERROR("AUTH_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Header Error"),
-    INVALID_ARGUMENT("COMMON_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Arguments");
+    INVALID_ARGUMENT("COMMON_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Arguments"),
+    AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider");
 
 
     private final String errorCode;

--- a/src/main/java/com/example/inflace/global/properties/GoogleProperties.java
+++ b/src/main/java/com/example/inflace/global/properties/GoogleProperties.java
@@ -1,0 +1,11 @@
+package com.example.inflace.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "google")
+public record GoogleProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri
+) {
+}

--- a/src/main/java/com/example/inflace/global/properties/JwtProperties.java
+++ b/src/main/java/com/example/inflace/global/properties/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.example.inflace.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long expiration
+) {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,9 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
 
 springdoc:
   api-docs:
@@ -14,6 +17,15 @@ springdoc:
   swagger-ui:
     path: /api-docs
     url: /v3/api-docs
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION}
 
 youtube:
   data-api:


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

#12 

---

## comment
<!-- 남길 코멘트 -->

oauth2 인증 기능 pr 보냅니다!

고도화때 카카오나 네이버같은 로그인도 고려하고 있다고 하신걸로 기억해서
추가하기 편하게 전략 패턴으로 설계해뒀습니다.

전에 외부 로그인 연결이 끊긴 기억이 있어서 추후에 retry 정도는 넣는거 고민해봐도 좋을거같습니다!

그리고, ddl-auto를 update로 해뒀는데 이러면 ddl때 오류가 좀 크게 났던걸로 기억해서
 나중에 none으로 하고 flyway로 버전 관리로 하는 것도 고민해봐야 할거 같습니다!

(+)
아직 redis 연결하고 reissue는 안해둬서 이것도 추후에 해야할거같습니다~

https://github.com/user-attachments/assets/d0fe5f35-e68b-4a7f-a8f4-8af3e27f037f

