### PR TITLE
In 117 유튜브 관련 기본 엔티티 셋팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
+    // jsonb를 사용하기 위해 추가
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 
     // jsonb를 사용하기 위해 추가
-    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.15.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/inflace/InflaceApplication.java
+++ b/src/main/java/com/example/inflace/InflaceApplication.java
@@ -3,7 +3,9 @@ package com.example.inflace;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class InflaceApplication {

--- a/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
@@ -1,0 +1,44 @@
+package com.example.inflace.domain.channel.domain;
+
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Channel extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "channel_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;  // login merge 후에 user entity와 연동 필요
+
+    private String name;
+
+    @Column(name = "youtube_channel_id")
+    private String youtubeChannelId;
+
+    private String category;
+
+    @Column(name = "entered_at")
+    private LocalDateTime enteredAt;
+
+    @Builder
+    public Channel(User user, String name, String youtubeChannelId, String category, LocalDateTime enteredAt) {
+        this.user = user;
+        this.name = name;
+        this.youtubeChannelId = youtubeChannelId;
+        this.category = category;
+        this.enteredAt = enteredAt;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -1,0 +1,46 @@
+package com.example.inflace.domain.channel.domain;
+
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_stats")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelStats extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "channel_stats_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    @Column(name = "subscriber_count")
+    private Long subscriberCount;
+
+    @Column(name = "total_view_count")
+    private Long totalViewCount;
+
+    @Column(name = "avg_engagement_rate")
+    private Double avgEngagementRate;
+
+    @Column(name = "collected_at")
+    private LocalDateTime collectedAt;
+
+    @Builder
+    public ChannelStats(Channel channel, Long subscriberCount, Long totalViewCount, Double avgEngagementRate, LocalDateTime collectedAt) {
+        this.channel = channel;
+        this.subscriberCount = subscriberCount;
+        this.totalViewCount = totalViewCount;
+        this.avgEngagementRate = avgEngagementRate;
+        this.collectedAt = collectedAt;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -1,13 +1,16 @@
 package com.example.inflace.domain.channel.domain;
 
 import com.example.inflace.global.entity.BaseEntity;
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Table(name = "channel_stats")
@@ -32,15 +35,32 @@ public class ChannelStats extends BaseEntity {
     @Column(name = "avg_engagement_rate")
     private Double avgEngagementRate;
 
+    @Type(JsonBinaryType.class)
+    @Column(name = "audience_gender", columnDefinition = "jsonb")
+    private Map<String, Double> audienceGender;
+
+    @Type(JsonBinaryType.class)
+    @Column(name = "audience_age", columnDefinition = "jsonb")
+    private Map<String, Double> audienceAge;
+
+    @Type(JsonBinaryType.class)
+    @Column(name = "audience_country", columnDefinition = "jsonb")
+    private Map<String, Double> audienceCountry;
+
     @Column(name = "collected_at")
     private LocalDateTime collectedAt;
 
     @Builder
-    public ChannelStats(Channel channel, Long subscriberCount, Long totalViewCount, Double avgEngagementRate, LocalDateTime collectedAt) {
+    public ChannelStats(Channel channel, Long subscriberCount, Long totalViewCount, Double avgEngagementRate,
+                        Map<String, Double> audienceGender, Map<String, Double> audienceAge,
+                        Map<String, Double> audienceCountry, LocalDateTime collectedAt) {
         this.channel = channel;
         this.subscriberCount = subscriberCount;
         this.totalViewCount = totalViewCount;
         this.avgEngagementRate = avgEngagementRate;
+        this.audienceGender = audienceGender;
+        this.audienceAge = audienceAge;
+        this.audienceCountry = audienceCountry;
         this.collectedAt = collectedAt;
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStatsHistory.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStatsHistory.java
@@ -1,0 +1,38 @@
+package com.example.inflace.domain.channel.domain;
+
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_stats_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelStatsHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "channel_stats_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    @Column(name = "subscriber_count")
+    private Long subscriberCount;
+
+    @Column(name = "recorded_date")
+    private LocalDateTime recordedDate;
+
+    @Builder
+    public ChannelStatsHistory(Channel channel, Long subscriberCount, LocalDateTime recordedDate) {
+        this.channel = channel;
+        this.subscriberCount = subscriberCount;
+        this.recordedDate = recordedDate;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/domain/AudienceRetention.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/AudienceRetention.java
@@ -1,0 +1,42 @@
+package com.example.inflace.domain.video.domain;
+
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audience_retention")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AudienceRetention extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "audience_retention_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_id", nullable = false)
+    private Video video;
+
+    @Column(name = "time_offset")
+    private Double timeOffset;
+
+    @Column(name = "retention_rate")
+    private Double retentionRate;
+
+    @Column(name = "collected_at")
+    private LocalDateTime collectedAt;
+
+    @Builder
+    public AudienceRetention(Video video, Double timeOffset, Double retentionRate, LocalDateTime collectedAt) {
+        this.video = video;
+        this.timeOffset = timeOffset;
+        this.retentionRate = retentionRate;
+        this.collectedAt = collectedAt;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/domain/Video.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/Video.java
@@ -47,7 +47,8 @@ public class Video extends BaseEntity {
     private String[] hashtags;
 
     @Builder
-    public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, int risingScore, LocalDateTime publishedAt, String[] hashtags) {
+    public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, int risingScore,
+                 LocalDateTime publishedAt, String[] hashtags) {
         this.channel = channel;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/example/inflace/domain/video/domain/Video.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/Video.java
@@ -2,13 +2,13 @@ package com.example.inflace.domain.video.domain;
 
 import com.example.inflace.domain.channel.domain.Channel;
 import com.example.inflace.global.entity.BaseEntity;
+import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 
@@ -42,8 +42,8 @@ public class Video extends BaseEntity {
     @Column(name = "published_at")
     private LocalDateTime publishedAt;
 
+    @Type(value = StringArrayType.class)
     @Column(name = "hashtags", columnDefinition = "text[]")
-    @JdbcTypeCode(SqlTypes.ARRAY)
     private String[] hashtags;
 
     @Builder

--- a/src/main/java/com/example/inflace/domain/video/domain/Video.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/Video.java
@@ -1,0 +1,60 @@
+package com.example.inflace.domain.video.domain;
+
+import com.example.inflace.domain.channel.domain.Channel;
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "video")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Video extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "video_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    private String title;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    private Double duration;
+
+    @Column(name = "is_short")
+    private boolean isShort;
+
+    @Column(name = "rising_score")
+    private int risingScore;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "hashtags", columnDefinition = "text[]")
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private String[] hashtags;
+
+    @Builder
+    public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, int risingScore, LocalDateTime publishedAt, String[] hashtags) {
+        this.channel = channel;
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.duration = duration;
+        this.isShort = isShort;
+        this.risingScore = risingScore;
+        this.publishedAt = publishedAt;
+        this.hashtags = hashtags;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
@@ -1,0 +1,57 @@
+package com.example.inflace.domain.video.domain;
+
+import com.example.inflace.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "video_stats")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VideoStats extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "video_stats_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_id", nullable = false)
+    private Video video;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "comment_count")
+    private Long commentCount;
+
+    @Column(name = "share_count")
+    private Long shareCount;
+
+    private Double ctr;
+
+    @Column(name = "avg_watch_duration")
+    private Double avgWatchDuration;
+
+    @Column(name = "collected_at")
+    private LocalDateTime collectedAt;
+
+    @Builder
+    public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount, Long shareCount, Double ctr, Double avgWatchDuration, LocalDateTime collectedAt) {
+        this.video = video;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.shareCount = shareCount;
+        this.ctr = ctr;
+        this.avgWatchDuration = avgWatchDuration;
+        this.collectedAt = collectedAt;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
@@ -44,7 +44,8 @@ public class VideoStats extends BaseEntity {
     private LocalDateTime collectedAt;
 
     @Builder
-    public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount, Long shareCount, Double ctr, Double avgWatchDuration, LocalDateTime collectedAt) {
+    public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount, Long shareCount, Double ctr,
+                      Double avgWatchDuration, LocalDateTime collectedAt) {
         this.video = video;
         this.viewCount = viewCount;
         this.likeCount = likeCount;

--- a/src/main/java/com/example/inflace/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/inflace/global/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.example.inflace.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/inflace/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/inflace/global/entity/BaseEntity.java
@@ -3,12 +3,14 @@ package com.example.inflace.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {  // 직접 인스턴스화 방지를 위해 추상 클래스 설정

--- a/src/main/java/com/example/inflace/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/inflace/global/entity/BaseEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public abstract class BaseEntity {  // 직접 인스턴스화 방지를 위해 추상 클래스 설정
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

#20 

---

## comment
<!-- 남길 코멘트 -->

- 유튜브 관련 엔티티들 셋팅했습니다.
- 현재 Channel에 User를 적어두었으나, 아직 로그인 pr이 합쳐지기 전이라 엔티티가 없어서 오류가 발생합니다! 머지 후에 import 하면 문제 없이 동작할 것 같습니다.
- 원래 테이블 생성하려면 ddl-auto 걸어야 하는데 규민님 pr에 이 부분 있던 것으로 기억해서 전 지워뒀습니다!
- 우선 user 엔티티 연관관계 잠시 지우고 & ddl auto 걸고 실험해본 결과, 다음과 같이 테이블 정상적으로 생성되는 것 전부 확인했습니다.

<img width="400" height="356" alt="스크린샷 2026-03-22 170950" src="https://github.com/user-attachments/assets/b797caea-0fe1-4d69-b23b-6579d8c4c7cf" />

### 논의하고 싶은 사항
- 단방향 연관관계를 우선으로 걸어두고 > 개발 진행하면서 양방향 연관관계가 필요할 시 연관관계 편의 메서드를 넣으면 어떨까..해서 현재는 단방향 연관관계만 걸어두었는데요, **우선 단방향 연관관계만 vs 전체 양방향 연관관계 매핑** 둘 중 어떤 방향이 좋을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채널 및 비디오 관련 엔티티(채널, 채널 통계·히스토리, 비디오, 비디오 통계, 청취자 유지율 등) 추가
  * 다양한 성능 지표(구독자·조회수·참여율 등)와 연령·성별·지역 분포 저장 지원
  * JPA 감사 기능 활성화로 모든 데이터에 대해 생성 및 수정 시간 자동 기록
<!-- end of auto-generated comment: release notes by coderabbit.ai -->