### PR TITLE
feat: google analytics <> oauth 연동 완료

### DIFF
--- a/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
@@ -3,6 +3,7 @@ package com.example.inflace.domain.auth.application;
 import com.example.inflace.domain.auth.presentation.dto.GoogleTokenResponse;
 import com.example.inflace.domain.auth.presentation.dto.GoogleUserInfoResponse;
 import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
+import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
 import com.example.inflace.global.client.GoogleApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,11 +13,14 @@ import org.springframework.stereotype.Component;
 public class GoogleLoginStrategy implements OAuthLoginStrategy {
 
     private final GoogleApiClient googleApiClient;
+    private final GoogleAccessTokenStore googleAccessTokenStore;
 
     @Override
     public OAuthUserInfo getUserInfo(String code) {
         GoogleTokenResponse token = googleApiClient.getToken(code);
         GoogleUserInfoResponse userInfo = googleApiClient.getUserInfo(token.accessToken());
+        googleAccessTokenStore.save(userInfo.email(), token.accessToken());  // TODO : 인메모리에 저장, 향후 REDIS로 옮기기
+
         return new OAuthUserInfo(userInfo.name(), userInfo.email(), userInfo.picture());
     }
 }

--- a/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
+++ b/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
@@ -1,5 +1,7 @@
 package com.example.inflace.domain.auth.util;
 
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -14,6 +16,10 @@ public class GoogleAccessTokenStore {
     }
 
     public String getAccessToken(String googleId) {
-        return tokenStore.get(googleId);
+        String token = tokenStore.get(googleId);
+        if (token == null) {
+            throw new ApiException(ErrorDefine.INVALID_HEADER_ERROR);
+        }
+        return token;
     }
 }

--- a/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
+++ b/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
@@ -1,0 +1,19 @@
+package com.example.inflace.domain.auth.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class GoogleAccessTokenStore {
+    private final Map<String, String> tokenStore = new ConcurrentHashMap<>();
+
+    public void save(String googleId, String accessToken) {
+        tokenStore.put(googleId, accessToken);
+    }
+
+    public String getAccessToken(String googleId) {
+        return tokenStore.get(googleId);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -4,6 +4,7 @@ import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
 import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoResponse;
 import com.example.inflace.domain.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,11 +23,13 @@ public class VideoController {
     // TODO : 포스트맨 test용 예시 컨트롤러. 차후 기능 개발 용으로는 API DTO 따로 짜서 연동 계획입니다!!
 //    @GetMapping("/analytics")
 //    public YoutubeAnalyticsVideoResponse getAnalytics(
+//            @AuthenticationPrincipal String googleId,
 //            @RequestParam String startDate,
 //            @RequestParam String endDate,
 //            @RequestParam List<String> metrics
 //    ) {
 //        return videoService.getYoutubeAnalyticsVideo(
+//                googleId,
 //                new YoutubeAnalyticsVideoRequest(
 //                        LocalDate.parse(startDate),
 //                        LocalDate.parse(endDate),

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -12,7 +12,7 @@ public class VideoService {
 
     private final YoutubeAnalyticsApiClient youtubeAnalyticsApiClient;
 
-    public YoutubeAnalyticsVideoResponse getYoutubeAnalyticsVideo(String googleId,
+    private YoutubeAnalyticsVideoResponse getYoutubeAnalyticsVideo(String googleId,
                                                                   YoutubeAnalyticsVideoRequest request) {
         YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(googleId, request);
         return response;

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -12,8 +12,9 @@ public class VideoService {
 
     private final YoutubeAnalyticsApiClient youtubeAnalyticsApiClient;
 
-    private YoutubeAnalyticsVideoResponse getYoutubeAnalyticsVideo(YoutubeAnalyticsVideoRequest request) {
-        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(request);
+    public YoutubeAnalyticsVideoResponse getYoutubeAnalyticsVideo(String googleId,
+                                                                  YoutubeAnalyticsVideoRequest request) {
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(googleId, request);
         return response;
     }
 }

--- a/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
@@ -1,5 +1,6 @@
 package com.example.inflace.global.client;
 
+import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
 import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
 import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoResponse;
 import com.example.inflace.global.properties.YoutubeProperties;
@@ -20,8 +21,9 @@ public class YoutubeAnalyticsApiClient {
 
     private final RestClient restClient;
     private final YoutubeProperties youtubeProperties;
+    private final GoogleAccessTokenStore googleAccessTokenStore;
 
-    public YoutubeAnalyticsVideoResponse getYoutubeAnalytics(YoutubeAnalyticsVideoRequest request) {
+    public YoutubeAnalyticsVideoResponse getYoutubeAnalytics(String googleId, YoutubeAnalyticsVideoRequest request) {
         URI uri = UriComponentsBuilder
                 .fromUriString(youtubeProperties.analyticsApi().baseUrl())
                 .path(ANALYTICS_PATH)
@@ -32,10 +34,9 @@ public class YoutubeAnalyticsApiClient {
                 .build()
                 .toUri();
 
-        // TODO : 차후 header에 access token 실어 보내는 방식으로 변경 예정
         return restClient.get()
                 .uri(uri)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + youtubeProperties.analyticsApi().accessToken())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessTokenStore.getAccessToken(googleId))
                 .retrieve()
                 .body(YoutubeAnalyticsVideoResponse.class);
     }


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #25 

---

## comment
<!-- 남길 코멘트 -->

- 로그인이 병합되어 analytics랑 oauth를 연동했습니다.
- 원래 video 계산식까지 붙여서 올릴까 하다가....이거 유성님 에픽인 2-2에서도 같이 써야하는걸로 알고 있어서 이 부분만 미리 올립니다!
- 현재 저희 공용 gcp는 접근이 안되는 것 같아서 제 개인 gcp 생성해서 로그인 키 만들어서 테스트했습니다!!
- 현재 google access token은 map 기반 인메모리로 저장해서 꺼내는 방식이고, 차후 redis 붙으면 redis 방식으로 옮기겠습니다!! 현재 동작에는 문제 없습니다.

<img width="1404" height="518" alt="image" src="https://github.com/user-attachments/assets/cdcb86a8-467d-4936-8736-a06e8fefcd19" />

- 주석 처리 되어있는 예시 test controller(연동 확인용 컨트롤러고 서비스에서 사용하는 컨트롤러 아닙니다!) 풀고 스웨거로 연동 test 가능합니다.
- **스웨거 test할 때는, 로그인 먼저 진행후 access token을 받아서 설정후 테스트 가능합니다!!**
- 제 계정 연동이라 뭘 올린 동영상이 없어서 매트릭이 따로 나오진 않네요..😯

```json
{
  "kind": "youtubeAnalytics#resultTable",
  "columnHeaders": [
    {
      "name": "views",
      "dataType": "INTEGER",
      "columnType": "METRIC"
    },
    {
      "name": "estimatedMinutesWatched",
      "dataType": "INTEGER",
      "columnType": "METRIC"
    },
    {
      "name": "averageViewDuration",
      "dataType": "INTEGER",
      "columnType": "METRIC"
    },
    {
      "name": "subscribersGained",
      "dataType": "INTEGER",
      "columnType": "METRIC"
    },
    {
      "name": "shares",
      "dataType": "INTEGER",
      "columnType": "METRIC"
    }
  ],
  "rows": [
    [
      0,
      0,
      0,
      0,
      0
    ]
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * YouTube 분석 API가 각 사용자의 Google 액세스 토큰을 사용하도록 변경되어 개인별 분석 데이터 조회가 더 정확하고 안정적입니다.
  * Google 로그인 시 액세스 토큰을 자동으로 저장·관리하여 로그인 기반 기능의 보안성과 신뢰성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->