### PR TITLE
chore: cd 실행 파일 말고 깃 시크릿 주입 실행으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,28 +39,46 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: youngh1p/inflace:latest
+          tags: |   # 버전 안정성을 위해 sha 태그로 관리                         
+            youngh1p/inflace:${{ github.sha }}
+            youngh1p/inflace:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v0.1.10
+        env: # secrets 변수 주입
+          IMAGE_TAG: ${{ github.sha }}
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          DATA_API_KEY: ${{ secrets.DATA_API_KEY }}
+          DATA_API_URL: ${{ secrets.DATA_API_URL }}
+          ANALYTICS_API_URL: ${{ secrets.ANALYTICS_API_URL }}
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: SPRING_DATASOURCE_URL,SPRING_DATASOURCE_USERNAME,SPRING_DATASOURCE_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,DATA_API_KEY,DATA_API_URL
+          envs: IMAGE_TAG,DB_URL,DB_USERNAME,DB_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,DATA_API_KEY,DATA_API_URL,ANALYTICS_API_URL,JWT_EXPIRATION,JWT_SECRET
           script: |
-            docker pull youngh1p/inflace:latest
+            docker pull youngh1p/inflace:$IMAGE_TAG
             docker stop inflace || true
             docker rm inflace || true
             docker run -d --name inflace -p 8080:8080 \
-              -e SPRING_DATASOURCE_URL=$SPRING_DATASOURCE_URL \
-              -e SPRING_DATASOURCE_USERNAME=$SPRING_DATASOURCE_USERNAME \
-              -e SPRING_DATASOURCE_PASSWORD=$SPRING_DATASOURCE_PASSWORD \
+              -e DB_URL=$DB_URL \
+              -e DB_USERNAME=$DB_USERNAME \
+              -e DB_PASSWORD=$DB_PASSWORD \
               -e GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
               -e GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
               -e GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI \
               -e DATA_API_KEY=$DATA_API_KEY \
               -e DATA_API_URL=$DATA_API_URL \
-              youngh1p/inflace:latest
+              -e ANALYTICS_API_URL=$ANALYTICS_API_URL \
+              -e JWT_EXPIRATION=$JWT_EXPIRATION \
+              -e JWT_SECRET=$JWT_SECRET \
+              youngh1p/inflace:$IMAGE_TAG

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,18 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: SPRING_DATASOURCE_URL,SPRING_DATASOURCE_USERNAME,SPRING_DATASOURCE_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,DATA_API_KEY,DATA_API_URL
           script: |
-            cd ~
-            ./deploy.sh
-
+            docker pull youngh1p/inflace:latest
+            docker stop inflace || true
+            docker rm inflace || true
+            docker run -d --name inflace -p 8080:8080 \
+              -e SPRING_DATASOURCE_URL=$SPRING_DATASOURCE_URL \
+              -e SPRING_DATASOURCE_USERNAME=$SPRING_DATASOURCE_USERNAME \
+              -e SPRING_DATASOURCE_PASSWORD=$SPRING_DATASOURCE_PASSWORD \
+              -e GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+              -e GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
+              -e GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI \
+              -e DATA_API_KEY=$DATA_API_KEY \
+              -e DATA_API_URL=$DATA_API_URL \
+              youngh1p/inflace:latest


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
#28 

---

## comment
<!-- 남길 코멘트 -->
- 원래 deploy.sh 로 ec2 내부에 실행 파일을 만들어서 docker를 띄우는 방식이었으나, 깃 시크릿 주입을 위해 해당 부분을 cd에 직접 삽입했습니다.
- 혹시 빠진 환경변수 있나 한 번 확인 부탁드립니다!
- 또한, 혹시 cd 설정에 이상한 부분이 있나 크로스 체킹 부탁드립니다.
- 모든 환경변수가 주입되고, cd가 메인에 올라가면 배포가 시작됩니다. main 머지 전에 ec2에서 deploy.sh 실행파일 없애두겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker 기반 배포 방식이 전면 도입되어 이미지에 커밋별 태그와 최신 태그가 함께 발행됩니다.
  * 원격 서버에서 이미지 풀 및 컨테이너 재시작으로 배포가 이루어지며, 비밀로 관리되는 환경 변수를 안전하게 주입하도록 워크플로우가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->