### PR TITLE
In 138 참여율 인기급상승 대시보드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 # Env
 .env
 .env.*
+
+# claude
+.claude/

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -1,0 +1,32 @@
+package com.example.inflace.domain.channel.controller;
+
+import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
+import com.example.inflace.global.exception.ApiErrorDefines;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Channel", description = "채널 관련 API")
+public interface ChannelApi {
+
+    @Operation(
+            summary = "인기 급상승 영상 Top 5",
+            description = "영상 타입별로 채널의 인기 급상승 Top 5 영상을 조회합니다. "
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    BaseResponse<ChannelTopVideosResponse> getTopVideos(
+            @PathVariable Long channelId,
+            @RequestParam String contentType
+    );
+
+    @Operation(
+            summary = "참여율 차트",
+            description = "채널의 롱폼/쇼츠 평균 참여율과 영상별 참여율 Top 5 리스트를 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    BaseResponse<ChannelEngagementRateResponse> getEngagementRateVideos(@PathVariable Long channelId);
+}

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -1,7 +1,14 @@
 package com.example.inflace.domain.channel.controller;
 
 import com.example.inflace.domain.channel.service.ChannelService;
+import com.example.inflace.domain.video.dto.ChannelTopVideosResponse;
+import com.example.inflace.global.exception.ApiErrorDefines;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChannelController {
 
     private final ChannelService channelService;
+
+    @GetMapping("/{channelId}/tops")
+    public BaseResponse<ChannelTopVideosResponse> getTopVideos(
+            @PathVariable Long channelId,
+            @RequestParam(defaultValue = "LONG_FORM") String contentType
+    ) {
+        return new BaseResponse<>(channelService.getTopVideos(channelId, contentType));
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -8,11 +8,13 @@ import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/channels")
 public class ChannelController {
 
     private final ChannelService channelService;

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -1,9 +1,8 @@
 package com.example.inflace.domain.channel.controller;
 
+import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
-import com.example.inflace.domain.video.dto.ChannelTopVideosResponse;
-import com.example.inflace.global.exception.ApiErrorDefines;
-import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,5 +24,12 @@ public class ChannelController {
             @RequestParam(defaultValue = "LONG_FORM") String contentType
     ) {
         return new BaseResponse<>(channelService.getTopVideos(channelId, contentType));
+    }
+
+    @GetMapping("/{channelId}/engagement-rate")
+    public BaseResponse<ChannelEngagementRateResponse> getEngagementRateVideos(
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>(channelService.getEngagementRateVideos(channelId));
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/channels")
-public class ChannelController {
+public class ChannelController implements ChannelApi{
 
     private final ChannelService channelService;
 

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelEngagementRateResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelEngagementRateResponse.java
@@ -1,0 +1,24 @@
+package com.example.inflace.domain.channel.dto;
+
+import java.util.List;
+
+public record ChannelEngagementRateResponse(
+        Summary summary,
+        List<EngageVideo> videos
+) {
+    public record Summary(
+            Double longFormAverageEngagementRate,
+            Double shortFormAverageEngagementRate
+    ) {
+    }
+
+    public record EngageVideo(
+            int rank,
+            Long videoId,
+            String title,
+            String thumbnailUrl,
+            String contentType,
+            Double engagementRate
+    ) {
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopVideosResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopVideosResponse.java
@@ -1,4 +1,4 @@
-package com.example.inflace.domain.video.dto;
+package com.example.inflace.domain.channel.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.channel.repository;
+
+import com.example.inflace.domain.channel.domain.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelRepository extends JpaRepository<Channel, Long> {
+}

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,9 +1,13 @@
 package com.example.inflace.domain.channel.service;
 
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
+import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.domain.VideoStats;
 import com.example.inflace.domain.video.dto.ChannelTopVideosResponse;
+import com.example.inflace.domain.video.dto.VideoType;
+import com.example.inflace.domain.video.repository.VideoRepository;
+import com.example.inflace.domain.video.repository.VideoStatsRepository;
 import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
@@ -21,6 +25,9 @@ import org.springframework.stereotype.Service;
 public class ChannelService {
 
     private final YoutubeDataApiClient youtubeDataApiClient;
+    private final ChannelRepository channelRepository;
+    private final VideoRepository videoRepository;
+    private final VideoStatsRepository videoStatsRepository;
 
     private YoutubeDataChannelResponse getYoutubeChannel(String channelId, String parts) {
         YoutubeDataChannelResponse response = youtubeDataApiClient.getYoutubeChannels(channelId, parts);
@@ -28,5 +35,77 @@ public class ChannelService {
     }
 
 
+    public ChannelTopVideosResponse getTopVideos(Long channelId, String contentType) {
+        validateChannelExists(channelId);
+
+        VideoType parsedContentType;
+        try {
+            parsedContentType = VideoType.valueOf(contentType.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new ApiException(ErrorDefine.INVALID_ARGUMENT);
+        }
+
+        List<Video> videos = videoRepository.findTopVideos(
+                channelId,
+                parsedContentType == VideoType.SHORT_FORM,
+                PageRequest.of(0, 5)
+        );
+
+        Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
+        List<ChannelTopVideosResponse.ChannelTopVideo> items = mapTopVideos(videos, videoStatsMap);
+        return new ChannelTopVideosResponse(items);
+    }
+
+    private void validateChannelExists(Long channelId) {
+        if (!channelRepository.existsById(channelId)) {
+            throw new ApiException(ErrorDefine.CHANNEL_NOT_FOUND);
+        }
+    }
+
+    private Map<Long, VideoStats> getVideoStatsMap(List<Video> videos) {
+        if (videos.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> videoIds = new ArrayList<>();
+        for (Video video : videos) {
+            videoIds.add(video.getId());
+        }
+
+        List<VideoStats> videoStatsList = videoStatsRepository.findAllByVideoIds(videoIds);
+        Map<Long, VideoStats> videoStatsMap = new HashMap<>();
+        for (VideoStats videoStats : videoStatsList) {
+            videoStatsMap.put(videoStats.getVideo().getId(), videoStats);
+        }
+
+        return videoStatsMap;
+    }
+
+    private List<ChannelTopVideosResponse.ChannelTopVideo> mapTopVideos(
+            List<Video> videos,
+            Map<Long, VideoStats> videoStatsMap
+    ) {
+        List<ChannelTopVideosResponse.ChannelTopVideo> items = new ArrayList<>();
+        int rank = 1;
+
+        for (Video video : videos) {
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+
+            items.add(new ChannelTopVideosResponse.ChannelTopVideo(
+                    rank,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    videoStats != null ? videoStats.getViewCount() : 0L,
+                    (double) video.getRisingScore(),
+                    videoStats != null && videoStats.getCtr() != null ? videoStats.getCtr() : 0.0,
+                    videoStats != null && videoStats.getAverageViewPercentage() != null
+                            ? videoStats.getAverageViewPercentage() : 0.0
+            ));
+
+            rank++;
+        }
+
+        return items;
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,8 +1,19 @@
 package com.example.inflace.domain.channel.service;
 
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.domain.VideoStats;
+import com.example.inflace.domain.video.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.client.YoutubeDataApiClient;
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +25,8 @@ public class ChannelService {
     private YoutubeDataChannelResponse getYoutubeChannel(String channelId, String parts) {
         YoutubeDataChannelResponse response = youtubeDataApiClient.getYoutubeChannels(channelId, parts);
         return response;
+    }
+
+
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -21,9 +21,11 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ChannelService {
 
     private final YoutubeDataApiClient youtubeDataApiClient;
@@ -31,6 +33,7 @@ public class ChannelService {
     private final VideoRepository videoRepository;
     private final VideoStatsRepository videoStatsRepository;
 
+    @Transactional(readOnly = true)
     public ChannelTopVideosResponse getTopVideos(Long channelId, String contentType) {
         validateChannelExists(channelId);
 
@@ -52,6 +55,7 @@ public class ChannelService {
         return new ChannelTopVideosResponse(items);
     }
 
+    @Transactional(readOnly = true)
     public ChannelEngagementRateResponse getEngagementRateVideos(Long channelId) {
         validateChannelExists(channelId);
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -108,7 +108,7 @@ public class ChannelService {
                     video.getTitle(),
                     video.getThumbnailUrl(),
                     videoStats != null ? videoStats.getViewCount() : 0L,
-                    (double) video.getRisingScore(),
+                    video.getRisingScore() != null ? video.getRisingScore() : 0.0,
                     videoStats != null && videoStats.getCtr() != null ? videoStats.getCtr() : 0.0,
                     videoStats != null && videoStats.getAverageViewPercentage() != null
                             ? videoStats.getAverageViewPercentage() : 0.0

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -46,7 +46,7 @@ public class ChannelService {
 
         List<Video> videos = videoRepository.findTopVideos(
                 channelId,
-                parsedContentType == VideoType.SHORT_FORM,
+                parsedContentType.isShort(),
                 PageRequest.of(0, 5)
         );
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,16 +1,18 @@
 package com.example.inflace.domain.channel.service;
 
+import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.domain.VideoStats;
-import com.example.inflace.domain.video.dto.ChannelTopVideosResponse;
+import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.domain.video.dto.VideoType;
 import com.example.inflace.domain.video.repository.VideoRepository;
 import com.example.inflace.domain.video.repository.VideoStatsRepository;
 import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.util.AnalyticsCalculator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,12 +30,6 @@ public class ChannelService {
     private final ChannelRepository channelRepository;
     private final VideoRepository videoRepository;
     private final VideoStatsRepository videoStatsRepository;
-
-    private YoutubeDataChannelResponse getYoutubeChannel(String channelId, String parts) {
-        YoutubeDataChannelResponse response = youtubeDataApiClient.getYoutubeChannels(channelId, parts);
-        return response;
-    }
-
 
     public ChannelTopVideosResponse getTopVideos(Long channelId, String contentType) {
         validateChannelExists(channelId);
@@ -54,6 +50,20 @@ public class ChannelService {
         Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
         List<ChannelTopVideosResponse.ChannelTopVideo> items = mapTopVideos(videos, videoStatsMap);
         return new ChannelTopVideosResponse(items);
+    }
+
+    public ChannelEngagementRateResponse getEngagementRateVideos(Long channelId) {
+        validateChannelExists(channelId);
+
+        List<Video> allVideos = videoRepository.findByChannelId(channelId);
+        Map<Long, VideoStats> allVideoStatsMap = getVideoStatsMap(allVideos);
+
+        double longFormAverage = calculateAverageEngagementRate(allVideos, allVideoStatsMap, false);
+        double shortFormAverage = calculateAverageEngagementRate(allVideos, allVideoStatsMap, true);
+
+        List<ChannelEngagementRateResponse.EngageVideo> items = mapEngagementRateItems(allVideos, allVideoStatsMap);
+
+        return new ChannelEngagementRateResponse(new ChannelEngagementRateResponse.Summary(longFormAverage, shortFormAverage), items);
     }
 
     private void validateChannelExists(Long channelId) {
@@ -81,10 +91,7 @@ public class ChannelService {
         return videoStatsMap;
     }
 
-    private List<ChannelTopVideosResponse.ChannelTopVideo> mapTopVideos(
-            List<Video> videos,
-            Map<Long, VideoStats> videoStatsMap
-    ) {
+    private List<ChannelTopVideosResponse.ChannelTopVideo> mapTopVideos(List<Video> videos, Map<Long, VideoStats> videoStatsMap) {
         List<ChannelTopVideosResponse.ChannelTopVideo> items = new ArrayList<>();
         int rank = 1;
 
@@ -107,5 +114,91 @@ public class ChannelService {
         }
 
         return items;
+    }
+
+    //참여율 도넛차트
+    private double calculateAverageEngagementRate(List<Video> videos, Map<Long, VideoStats> videoStatsMap, boolean isShort) {
+        long totalLikeCount = 0L;
+        long totalCommentCount = 0L;
+        long totalViewCount = 0L;
+
+        for (Video video : videos) {
+            if (video.isShort() != isShort) {
+                continue;
+            }
+
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+            if (videoStats == null) {
+                continue;
+            }
+
+            totalLikeCount += videoStats.getLikeCount() != null ? videoStats.getLikeCount() : 0L;
+            totalCommentCount += videoStats.getCommentCount() != null ? videoStats.getCommentCount() : 0L;
+            totalViewCount += videoStats.getViewCount() != null ? videoStats.getViewCount() : 0L;
+        }
+
+        if (totalViewCount == 0L) {
+            return 0.0;
+        }
+
+        return AnalyticsCalculator.engagementRate(totalLikeCount, totalCommentCount, totalViewCount);
+    }
+
+    //참여율 항목 만들기
+    private List<ChannelEngagementRateResponse.EngageVideo> mapEngagementRateItems(List<Video> videos, Map<Long, VideoStats> videoStatsMap) {
+        List<ChannelEngagementRateResponse.EngageVideo> items = new ArrayList<>();
+
+        for (Video video : videos) {
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+            if (videoStats == null) {
+                continue;
+            }
+
+            items.add(new ChannelEngagementRateResponse.EngageVideo(
+                    0,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    video.isShort() ? VideoType.SHORT_FORM.name() : VideoType.LONG_FORM.name(),
+                    AnalyticsCalculator.engagementRate(
+                            videoStats.getLikeCount(),
+                            videoStats.getCommentCount(),
+                            videoStats.getViewCount()
+                    )
+            ));
+        }
+
+        items.sort((item1, item2) -> {
+            int compareEngagementRate = Double.compare(item2.engagementRate(), item1.engagementRate());
+            if (compareEngagementRate != 0) {
+                return compareEngagementRate;
+            }
+            return Long.compare(item2.videoId(), item1.videoId());
+        });
+
+        List<ChannelEngagementRateResponse.EngageVideo> rankedItems = new ArrayList<>();
+        int rank = 1;
+        for (ChannelEngagementRateResponse.EngageVideo item : items) {
+            if (rank > 5) {
+                break;
+            }
+
+            rankedItems.add(new ChannelEngagementRateResponse.EngageVideo(
+                    rank,
+                    item.videoId(),
+                    item.title(),
+                    item.thumbnailUrl(),
+                    item.contentType(),
+                    item.engagementRate()
+            ));
+            rank++;
+        }
+
+        return rankedItems;
+    }
+
+    private YoutubeDataChannelResponse getYoutubeChannel(String channelId, String parts) {
+        YoutubeDataChannelResponse response = youtubeDataApiClient.getYoutubeChannels(channelId, parts);
+        return response;
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/domain/AudienceRetention.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/AudienceRetention.java
@@ -32,11 +32,16 @@ public class AudienceRetention extends BaseEntity {
     @Column(name = "collected_at")
     private LocalDateTime collectedAt;
 
+    @Column(name = "relative_retention_performance")
+    private Long relativeRetentionPerformance;
+
     @Builder
-    public AudienceRetention(Video video, Double timeOffset, Double retentionRate, LocalDateTime collectedAt) {
+    public AudienceRetention(Video video, Double timeOffset, Double retentionRate,
+                             LocalDateTime collectedAt, Long relativeRetentionPerformance) {
         this.video = video;
         this.timeOffset = timeOffset;
         this.retentionRate = retentionRate;
         this.collectedAt = collectedAt;
+        this.relativeRetentionPerformance = relativeRetentionPerformance;
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/domain/Video.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/Video.java
@@ -37,7 +37,7 @@ public class Video extends BaseEntity {
     private boolean isShort;
 
     @Column(name = "rising_score")
-    private int risingScore;
+    private Double risingScore;
 
     @Column(name = "published_at")
     private LocalDateTime publishedAt;
@@ -46,9 +46,12 @@ public class Video extends BaseEntity {
     @Column(name = "hashtags", columnDefinition = "text[]")
     private String[] hashtags;
 
+    @Column(name = "youtube_video_id")
+    private String youtubeVideoId;
+
     @Builder
-    public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, int risingScore,
-                 LocalDateTime publishedAt, String[] hashtags) {
+    public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, Double risingScore,
+                 LocalDateTime publishedAt, String[] hashtags, String youtubeVideoId) {
         this.channel = channel;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
@@ -57,5 +60,6 @@ public class Video extends BaseEntity {
         this.risingScore = risingScore;
         this.publishedAt = publishedAt;
         this.hashtags = hashtags;
+        this.youtubeVideoId = youtubeVideoId;
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
@@ -43,9 +43,19 @@ public class VideoStats extends BaseEntity {
     @Column(name = "collected_at")
     private LocalDateTime collectedAt;
 
+    @Column(name = "subscribers_gained")
+    private Long subscribersGained;
+
+    @Column(name = "unsubscribed_view_count")
+    private Long unsubscribedViewCount;
+
+    @Column(name = "average_view_percentage")
+    private Double averageViewPercentage;
+
     @Builder
     public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount, Long shareCount, Double ctr,
-                      Double avgWatchDuration, LocalDateTime collectedAt) {
+                      Double avgWatchDuration, LocalDateTime collectedAt, Long subscribersGained,
+                      Long unsubscribedViewCount, Double averageViewPercentage) {
         this.video = video;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
@@ -54,5 +64,8 @@ public class VideoStats extends BaseEntity {
         this.ctr = ctr;
         this.avgWatchDuration = avgWatchDuration;
         this.collectedAt = collectedAt;
+        this.subscribersGained = subscribersGained;
+        this.unsubscribedViewCount = unsubscribedViewCount;
+        this.averageViewPercentage = averageViewPercentage;
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/dto/ChannelTopVideosResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/ChannelTopVideosResponse.java
@@ -1,0 +1,19 @@
+package com.example.inflace.domain.video.dto;
+
+import java.util.List;
+
+public record ChannelTopVideosResponse(
+        List<ChannelTopVideo> videos
+) {
+    public record ChannelTopVideo(
+            Integer rank,
+            Long videoId,
+            String title,
+            String thumbnailUrl,
+            Long viewCount,
+            Double engagementRate,
+            Double ctr,
+            Double retentionRate
+    ){
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/dto/VideoType.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/VideoType.java
@@ -1,0 +1,6 @@
+package com.example.inflace.domain.video.dto;
+
+public enum VideoType {
+    LONG_FORM,
+    SHORT_FORM
+}

--- a/src/main/java/com/example/inflace/domain/video/dto/VideoType.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/VideoType.java
@@ -2,5 +2,9 @@ package com.example.inflace.domain.video.dto;
 
 public enum VideoType {
     LONG_FORM,
-    SHORT_FORM
+    SHORT_FORM;
+
+    public boolean isShort() {
+        return this == SHORT_FORM;
+    }
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -11,7 +11,7 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
     @Query("""
             select v
             from Video v
-            join VideoStats vs on vs.video = v
+            left join VideoStats vs on vs.video = v
             where v.channel.id = :channelId
               and v.isShort = :isShort
             order by v.risingScore desc, vs.ctr desc, v.id desc

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -1,7 +1,24 @@
 package com.example.inflace.domain.video.repository;
 
 import com.example.inflace.domain.video.domain.Video;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VideoRepository extends JpaRepository<Video, Long> {
+    @Query("""
+            select v
+            from Video v
+            join VideoStats vs on vs.video = v
+            where v.channel.id = :channelId
+              and v.isShort = :isShort
+            order by v.risingScore desc, vs.ctr desc, v.id desc
+            """)
+    List<Video> findTopVideos(
+            @Param("channelId") Long channelId,
+            @Param("isShort") boolean isShort,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -14,7 +14,7 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             left join VideoStats vs on vs.video = v
             where v.channel.id = :channelId
               and v.isShort = :isShort
-            order by v.risingScore desc, vs.ctr desc, v.id desc
+            order by coalesce(v.risingScore, 0) desc, coalesce(vs.ctr, 0) desc, v.id desc
             """)
     List<Video> findTopVideos(
             @Param("channelId") Long channelId,

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -21,4 +21,6 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             @Param("isShort") boolean isShort,
             Pageable pageable
     );
+
+    List<Video> findByChannelId(Long channelId);
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.video.repository;
+
+import com.example.inflace.domain.video.domain.Video;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoRepository extends JpaRepository<Video, Long> {
+}

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoStatsRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoStatsRepository.java
@@ -1,7 +1,16 @@
 package com.example.inflace.domain.video.repository;
 
 import com.example.inflace.domain.video.domain.VideoStats;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VideoStatsRepository extends JpaRepository<VideoStats, Long> {
+    @Query("""
+            select vs
+            from VideoStats vs
+            where vs.video.id in :videoIds
+            """)
+    List<VideoStats> findAllByVideoIds(@Param("videoIds") List<Long> videoIds);
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoStatsRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoStatsRepository.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.video.repository;
+
+import com.example.inflace.domain.video.domain.VideoStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoStatsRepository extends JpaRepository<VideoStats, Long> {
+}

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -8,8 +8,8 @@ public enum ErrorDefine {
 
     INVALID_HEADER_ERROR("AUTH_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Header Error"),
     INVALID_ARGUMENT("COMMON_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Arguments"),
-    AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider");
-
+    AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider"),
+    CHANNEL_NOT_FOUND("CHANNEL_404", HttpStatus.NOT_FOUND, "Not Found: Channel Not Found");
 
     private final String errorCode;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
##  Issue
closed #32 

---

## comment
인기 급상승 대시보드와 롱폼/참여율 차트 조회를 구현하였습니다.
단순 CRUD 로직인 만큼 로컬에서 더미 데이터를 넣고 테스트를 해보았습니다.
+ erdCloud에 추가된 필드들 추가하였습니다.

<img width="483" height="290" alt="image" src="https://github.com/user-attachments/assets/3e01c917-e0fd-4e97-ac32-32fc034faa1f" />
<img width="571" height="303" alt="image" src="https://github.com/user-attachments/assets/f6a847e8-b72a-42fc-ae7a-39b653099902" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채널 인기 영상 조회 API 추가 — 콘텐츠 유형별 상위 영상(최대 5개) 제공
  * 채널 참여도 분석 API 추가 — 장르별 평균 참여도 및 상위 5개 영상 순위·세부정보 제공
  * 채널 미존재 시 404 응답(채널 없음) 처리 추가

* **데이터 모델 변경**
  * 영상 엔티티에 외부 식별자 및 상승 지표 타입 개선
  * 통계 엔티티에 구독자 증감·이탈 조회수·평균 시청비율 필드 추가
  * 영상 유형(enum) 도입

* **기타(환경)**
  * 개발환경 무시 규칙(.gitignore) 업데이트 (새 디렉터리 제외 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->