### PR TITLE
IN 146 2 4 시청 지속률 요약 통계 구현 완료

### DIFF
--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.video.controller;
 
 import com.example.inflace.domain.video.dto.AudienceRetentionResponse;
+import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
 import com.example.inflace.global.exception.ApiErrorDefines;
@@ -40,4 +41,13 @@ public interface VideoApi {
     @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<AudienceRetentionResponse> getRetention(@AuthenticationPrincipal String email,
                                                          @PathVariable("videoId") Long videoId);
+
+    @Operation(
+            summary = "에픽 2-4, 비디오 시청 지속률 요약 통계",
+            description = "비디오 ID로 시청 지속률 요약 통계를 조회합니다. <br>" +
+                    "평균 시청 지속 시간(초)과 평균 대비 유지율을 반환합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.VIDEO_STATS_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
+    BaseResponse<RetentionSummaryResponse> getRetentionSummary(@AuthenticationPrincipal String email,
+                                                               @PathVariable("videoId") Long videoId);
 }

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.video.controller;
 
 import com.example.inflace.domain.video.dto.AudienceRetentionResponse;
+import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
 import com.example.inflace.domain.video.service.VideoService;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/video")
+@RequestMapping("/api/v1/videos")
 public class VideoController implements VideoApi {
 
     private final VideoService videoService;
@@ -43,6 +44,16 @@ public class VideoController implements VideoApi {
             @PathVariable Long videoId
     ) {
         AudienceRetentionResponse response = videoService.getRetention(email, videoId);
+        return new BaseResponse<>(response);
+    }
+
+    @Override
+    @GetMapping("/{videoId}/retention/summary")
+    public BaseResponse<RetentionSummaryResponse> getRetentionSummary(
+            @AuthenticationPrincipal String email,
+            @PathVariable Long videoId
+    ) {
+        RetentionSummaryResponse response = videoService.getRetentionSummary(email, videoId);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/dto/RetentionSummaryResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/RetentionSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.example.inflace.domain.video.dto;
+
+import com.example.inflace.domain.video.domain.VideoStats;
+
+public record RetentionSummaryResponse(RetentionData retentionData) {
+
+    public record RetentionData(
+            Double avgWatchDuration,
+            Double relativeRetentionAvg
+    ) {
+    }
+
+    public static RetentionSummaryResponse from(VideoStats stats) {
+        return new RetentionSummaryResponse(
+                new RetentionData(
+                        stats.getAvgWatchDuration(),
+                        stats.getRelativeRetentionPerformance()
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -63,6 +63,18 @@ public class VideoService {
         return AudienceRetentionResponse.from(retentionList);
     }
 
+    public RetentionSummaryResponse getRetentionSummary(String email, Long videoId) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
+
+        validateVideoOwnership(video, email);
+
+        VideoStats videoStats = videoStatsRepository.findByVideo(video)
+                .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_STATS_NOT_FOUND));
+
+        return RetentionSummaryResponse.from(videoStats);
+    }
+
     private void validateVideoOwnership(Video video, String email) {
         String ownerEmail = video.getChannel().getUser().getEmail();
         if (!ownerEmail.equals(email)) {


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
- 제 티켓에서 지라 이슈가 안생겨서 일단 이대로 진행합니다..!

---

## comment
<!-- 남길 코멘트 -->
- 시청 지속률 요약 통계 api를 구현했습니다.
- 해당 api는 사실 db값을 그대로 가져오는거라 (유효성 검사 후)... 차후 유튜브에서 데이터를 받아서 db에 저장하는 로직이 중요할 것으로 생각됩니다.
- 현재 db 내부의 더미데이터는 잘 가져와집니다.

<img width="445" height="231" alt="image" src="https://github.com/user-attachments/assets/d9c09af1-fbad-474a-a730-c8c9a9f65a58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 영상별 시청 유지율 요약 조회 API 추가 - 평균 시청 시간 및 상대 유지율 성과 지표 제공

## 변경사항
* API 기본 경로 업데이트: v1/video에서 v1/videos로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->