### PR TITLE
In 153 신규유입 대시보드 구현

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -1,6 +1,8 @@
 package com.example.inflace.domain.channel.controller;
 
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
+import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
@@ -29,4 +31,18 @@ public interface ChannelApi {
     )
     @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
     BaseResponse<ChannelEngagementRateResponse> getEngagementRateVideos(@PathVariable Long channelId);
+
+    @Operation(
+            summary = "신규 유입 비율 TOP 영상",
+            description = "채널의 신규 유입 비율이 높은 상위 5개 영상을 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    BaseResponse<ChannelNewSubscriberResponse> getNewSubscriberVideos(@PathVariable Long channelId);
+
+    @Operation(
+            summary = "핵심 지표 카드(KPI)",
+            description = "채널의 핵심 지표 카드를 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    BaseResponse<ChannelKpiResponse> getChannelKpi(@PathVariable Long channelId);
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -43,7 +43,7 @@ public class ChannelController implements ChannelApi{
     }
 
     @GetMapping("/{channelId}/kpi")
-    public BaseResponse<ChannelKpiResponse> getKpi(
+    public BaseResponse<ChannelKpiResponse> getChannelKpi(
             @PathVariable Long channelId
     ) {
         return new BaseResponse<>(channelService.getChannelKpi(channelId));

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -38,6 +38,6 @@ public class ChannelController implements ChannelApi{
     public BaseResponse<ChannelNewSubscriberResponse> getNewSubscriberVideos(
             @PathVariable Long channelId
     ) {
-        return new BaseResponse<>();
+        return new BaseResponse<>(channelService.getNewSubscriberVideos(channelId));
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -46,6 +46,6 @@ public class ChannelController implements ChannelApi{
     public BaseResponse<ChannelKpiResponse> getKpi(
             @PathVariable Long channelId
     ) {
-        return new BaseResponse<>(channelService.getKpi(channelId));
+        return new BaseResponse<>(channelService.getChannelKpi(channelId));
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.channel.controller;
 
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.response.BaseResponse;
@@ -31,5 +32,12 @@ public class ChannelController implements ChannelApi{
             @PathVariable Long channelId
     ) {
         return new BaseResponse<>(channelService.getEngagementRateVideos(channelId));
+    }
+
+    @GetMapping("/{channelId}/new-subscriber")
+    public BaseResponse<ChannelNewSubscriberResponse> getNewSubscriberVideos(
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>();
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.channel.controller;
 
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
@@ -39,5 +40,12 @@ public class ChannelController implements ChannelApi{
             @PathVariable Long channelId
     ) {
         return new BaseResponse<>(channelService.getNewSubscriberVideos(channelId));
+    }
+
+    @GetMapping("/{channelId}/kpi")
+    public BaseResponse<ChannelKpiResponse> getKpi(
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>(channelService.getKpi(channelId));
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
@@ -1,0 +1,9 @@
+package com.example.inflace.domain.channel.dto;
+
+public record ChannelKpiResponse(
+        Long totalViews,
+        Double avgEngagementRate,
+        Double avgViewDuration,
+        Double weeklyUploadCount
+) {
+}

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
@@ -3,7 +3,7 @@ package com.example.inflace.domain.channel.dto;
 public record ChannelKpiResponse(
         Long totalViews,
         Double avgEngagementRate,
-        Double avgViewDuration,
+        Double avgRetentionRate,
         Double weeklyUploadCount
 ) {
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelNewSubscriberResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelNewSubscriberResponse.java
@@ -1,0 +1,19 @@
+package com.example.inflace.domain.channel.dto;
+
+import java.util.List;
+
+public record ChannelNewSubscriberResponse(
+        List<NewSubscriberVideo> videos
+) {
+    public record NewSubscriberVideo(
+            int rank,
+            Long videoId,
+            String title,
+            String thumbnailUrl,
+            Long viewCount,
+            Long subscriptionConversionCount,
+            Double newSubscriberRatio,
+            Double retentionRate
+    ) {
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelStatsRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelStatsRepository.java
@@ -1,0 +1,10 @@
+package com.example.inflace.domain.channel.repository;
+
+import com.example.inflace.domain.channel.domain.ChannelStats;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelStatsRepository extends JpaRepository<ChannelStats, Long> {
+    Optional<ChannelStats> findByChannelId(Long channelId);
+}
+

--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelStatsRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelStatsRepository.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelStatsRepository extends JpaRepository<ChannelStats, Long> {
-    Optional<ChannelStats> findByChannelId(Long channelId);
+    Optional<ChannelStats> findByChannel_Id(Long channelId);
 }
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -2,6 +2,7 @@ package com.example.inflace.domain.channel.service;
 
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse.NewSubscriberVideo;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.video.domain.Video;
@@ -79,6 +80,30 @@ public class ChannelService {
                 channelId,
                 PageRequest.of(0,5)
         );
+
+        Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
+        List<NewSubscriberVideo> items = new ArrayList<>();
+
+        int rank = 1;
+        for (Video video : videos) {
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+
+            items.add(new NewSubscriberVideo(
+                    rank,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    videoStats != null ? videoStats.getViewCount() : 0L,
+                    videoStats != null ? videoStats.getSubscribersGained() : 0L,
+                    videoStats != null && videoStats.getUnsubscribedViewerPercentage() != null
+                            ? videoStats.getUnsubscribedViewerPercentage() : 0.0,
+                    videoStats != null && videoStats.getAverageViewPercentage() != null
+                            ? videoStats.getAverageViewPercentage() : 0.0
+            ));
+            rank++;
+        }
+
+        return new ChannelNewSubscriberResponse(items);
     }
 
     private void validateChannelExists(Long channelId) {

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,10 +1,13 @@
 package com.example.inflace.domain.channel.service;
 
+import com.example.inflace.domain.channel.domain.ChannelStats;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse.NewSubscriberVideo;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
+import com.example.inflace.domain.channel.repository.ChannelStatsRepository;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.domain.VideoStats;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
@@ -15,6 +18,7 @@ import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.util.AnalyticsCalculator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,6 +37,7 @@ public class ChannelService {
     private final YoutubeDataApiClient youtubeDataApiClient;
     private final ChannelRepository channelRepository;
     private final VideoRepository videoRepository;
+    private final ChannelStatsRepository channelStatsRepository;
     private final VideoStatsRepository videoStatsRepository;
 
     @Transactional(readOnly = true)
@@ -104,6 +109,28 @@ public class ChannelService {
         }
 
         return new ChannelNewSubscriberResponse(items);
+    }
+
+    @Transactional(readOnly = true)
+    public ChannelKpiResponse getChannelKpi(Long channelId) {
+        validateChannelExists(channelId);
+
+        ChannelStats channelStats = channelStatsRepository.findByChannelId(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
+
+        List<Video> videos = videoRepository.findByChannelId(channelId);
+        Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
+
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusDays(30);
+        Long recentUploadCount = videoRepository.countByChannelIdAndPublishedAtGreaterThanEqual(channelId, oneMonthAgo);
+        double weeklyUploadCount = Math.round((recentUploadCount / (30.0 / 7.0)) * 100) / 100.0;
+
+        return new ChannelKpiResponse(
+                channelStats.getTotalViewCount() != null ? channelStats.getTotalViewCount() : 0L,
+                channelStats.getAvgEngagementRate() != null ? channelStats.getAvgEngagementRate() : 0.0,
+                calculateAverageRetentionRate(videos, videoStatsMap),
+                weeklyUploadCount
+        );
     }
 
     private void validateChannelExists(Long channelId) {
@@ -235,6 +262,24 @@ public class ChannelService {
         }
 
         return rankedItems;
+    }
+
+    //채널 참여율 평균 구하기
+    private double calculateAverageRetentionRate(List<Video> videos, Map<Long, VideoStats> videoStatsMap) {
+        double totalAverageViewPercentage = 0.0;
+        int count = 0;
+
+        for (Video video : videos) {
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+            if (videoStats == null || videoStats.getAverageViewPercentage() == null) {
+                continue;
+            }
+
+            totalAverageViewPercentage += videoStats.getAverageViewPercentage();
+            count++;
+        }
+
+        return count == 0 ? 0.0 : totalAverageViewPercentage / count;
     }
 
     private YoutubeDataChannelResponse getYoutubeChannel(String channelId, String parts) {

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -115,7 +115,7 @@ public class ChannelService {
     public ChannelKpiResponse getChannelKpi(Long channelId) {
         validateChannelExists(channelId);
 
-        ChannelStats channelStats = channelStatsRepository.findByChannelId(channelId)
+        ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
 
         List<Video> videos = videoRepository.findByChannelId(channelId);

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.channel.service;
 
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
+import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.video.domain.Video;
@@ -68,6 +69,16 @@ public class ChannelService {
         List<ChannelEngagementRateResponse.EngageVideo> items = mapEngagementRateItems(allVideos, allVideoStatsMap);
 
         return new ChannelEngagementRateResponse(new ChannelEngagementRateResponse.Summary(longFormAverage, shortFormAverage), items);
+    }
+
+    @Transactional(readOnly = true)
+    public ChannelNewSubscriberResponse getNewSubscriberVideos(Long channelId) {
+        validateChannelExists(channelId);
+
+        List<Video> videos = videoRepository.findTopNewSubscriberVideos(
+                channelId,
+                PageRequest.of(0,5)
+        );
     }
 
     private void validateChannelExists(Long channelId) {

--- a/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
@@ -52,10 +52,14 @@ public class VideoStats extends BaseEntity {
     @Column(name = "relative_retention_performance")
     private Double relativeRetentionPerformance;
 
+    @Column(name = "unsubscribed_viewer_percentage")
+    private Double unsubscribedViewerPercentage;
+
     @Builder
     public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount, Long shareCount, Double ctr,
                       Double avgWatchDuration, LocalDateTime collectedAt, Long subscribersGained,
-                      Long unsubscribedViewCount, Double averageViewPercentage, Double relativeRetentionPerformance) {
+                      Long unsubscribedViewCount, Double averageViewPercentage, Double relativeRetentionPerformance,
+                      Double unsubscribedViewerPercentage) {
         this.video = video;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
@@ -68,5 +72,6 @@ public class VideoStats extends BaseEntity {
         this.unsubscribedViewCount = unsubscribedViewCount;
         this.averageViewPercentage = averageViewPercentage;
         this.relativeRetentionPerformance = relativeRetentionPerformance;
+        this.unsubscribedViewerPercentage = unsubscribedViewerPercentage;
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.video.repository;
 
 import com.example.inflace.domain.video.domain.Video;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,6 +34,8 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             @Param("channelId") Long channelId,
             Pageable pageable
     );
+
+    Long countByChannelIdAndPublishedAtGreaterThanEqual(Long channelId, LocalDateTime publishedAt);
 
     List<Video> findByChannelId(Long channelId);
 }

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -22,5 +22,17 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             Pageable pageable
     );
 
+    @Query("""
+       select v
+       from Video v
+       left join VideoStats vs on vs.video = v
+       where v.channel.id = :channelId
+       order by coalesce(vs.unsubscribedViewerPercentage, 0) desc, v.id desc
+    """)
+    List<Video> findTopNewSubscriberVideos(
+            @Param("channelId") Long channelId,
+            Pageable pageable
+    );
+
     List<Video> findByChannelId(Long channelId);
 }

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -16,7 +16,9 @@ public enum ErrorDefine {
     VIDEO_STATS_NOT_FOUND("VIDEO_STATS_404", HttpStatus.NOT_FOUND, "Not Found: Video Stats not found"),
     RETENTION_NOT_FOUND("RETENTION_404", HttpStatus.NOT_FOUND, "Not Found: Retention not found"),
 
-    CHANNEL_NOT_FOUND("CHANNEL_404", HttpStatus.NOT_FOUND, "Not Found: Channel Not Found");
+    //CHANNEL
+    CHANNEL_NOT_FOUND("CHANNEL_404", HttpStatus.NOT_FOUND, "Not Found: Channel Not Found"),
+    CHANNEL_STATS_NOT_FOUND("CHANNEL_STATS_404", HttpStatus.NOT_FOUND, " Not Found: Channel Stats not found");
 
     private final String errorCode;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
##  Issue
 closed #37

---

## comment
신규유입 Top5 대시보드와
KPI 대시보드(핵심 지표카드)를 구현하였습니다.

+지라에 등록했는데 깃허브에 등록되지 않는 문제가 있어 다영님께 여쭤 보니, 저희 플랜 월별 사용량을 이번달은 다 소진했다고 하더라고요 아마 내일부터는 정상 작동되지 않을까 싶습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채널의 신규 구독자 유입에 기여한 동영상 목록 조회 API 추가
  * 채널 핵심 성과 지표(총 조회수, 평균 참여율, 평균 시청 유지율, 주간 업로드 수) 조회 API 추가

* **버그 수정 / 개선**
  * 채널 통계가 없을 때의 오류 처리 강화(별도 오류 코드 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->