### PR TITLE
In 147 2 4 개별 영상 대시보드 api 시청 구간별 이탈률 정보 완성

### DIFF
--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.video.controller;
 
 import com.example.inflace.domain.video.dto.AudienceRetentionResponse;
+import com.example.inflace.domain.video.dto.DropPointsResponse;
 import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
@@ -41,6 +42,15 @@ public interface VideoApi {
     @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<AudienceRetentionResponse> getRetention(@AuthenticationPrincipal String email,
                                                          @PathVariable("videoId") Long videoId);
+
+    @Operation(
+            summary = "에픽 2-4, 비디오 이탈 구간",
+            description = "비디오 ID로 구간별 평균 이탈률을 조회합니다. <br>" +
+                    "100개의 시청 지속률 데이터를 25개씩 4구간으로 나눠 각 구간의 평균 이탈률을 반환합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
+    BaseResponse<DropPointsResponse> getDropPoints(@AuthenticationPrincipal String email,
+                                                   @PathVariable("videoId") Long videoId);
 
     @Operation(
             summary = "에픽 2-4, 비디오 시청 지속률 요약 통계",

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -48,7 +48,7 @@ public interface VideoApi {
             description = "비디오 ID로 구간별 평균 이탈률을 조회합니다. <br>" +
                     "100개의 시청 지속률 데이터를 25개씩 4구간으로 나눠 각 구간의 평균 이탈률을 반환합니다."
     )
-    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
+    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.RETENTION_INVALID})
     BaseResponse<DropPointsResponse> getDropPoints(@AuthenticationPrincipal String email,
                                                    @PathVariable("videoId") Long videoId);
 

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -48,7 +48,7 @@ public interface VideoApi {
             description = "비디오 ID로 구간별 평균 이탈률을 조회합니다. <br>" +
                     "100개의 시청 지속률 데이터를 25개씩 4구간으로 나눠 각 구간의 평균 이탈률을 반환합니다."
     )
-    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.RETENTION_INVALID})
+    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.RETENTION_INVALID, ErrorDefine.INVALID_ARGUMENT})
     BaseResponse<DropPointsResponse> getDropPoints(@AuthenticationPrincipal String email,
                                                    @PathVariable("videoId") Long videoId);
 

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.video.controller;
 
 import com.example.inflace.domain.video.dto.AudienceRetentionResponse;
+import com.example.inflace.domain.video.dto.DropPointsResponse;
 import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
@@ -44,6 +45,16 @@ public class VideoController implements VideoApi {
             @PathVariable Long videoId
     ) {
         AudienceRetentionResponse response = videoService.getRetention(email, videoId);
+        return new BaseResponse<>(response);
+    }
+
+    @Override
+    @GetMapping("/{videoId}/retention/drop-points")
+    public BaseResponse<DropPointsResponse> getDropPoints(
+            @AuthenticationPrincipal String email,
+            @PathVariable Long videoId
+    ) {
+        DropPointsResponse response = videoService.getDropPoints(email, videoId);
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/example/inflace/domain/video/dto/DropPointsResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/DropPointsResponse.java
@@ -18,27 +18,31 @@ public record DropPointsResponse(List<DropPoint> dropPoints) {
         List<DropPoint> dropPoints = new ArrayList<>();
 
         for (int i = 0; i < SEGMENT_COUNT; i++) {
-            int from = i * SEGMENT_SIZE;
-            int to = from + SEGMENT_SIZE;
+            List<AudienceRetention> segment = retentionList.subList(i * SEGMENT_SIZE, (i + 1) * SEGMENT_SIZE);
 
-            List<AudienceRetention> segment = retentionList.subList(from, to);
-
-            List<Double> rates = segment.stream()
-                    .map(AudienceRetention::getRetentionRate)
-                    .toList();
-
-            String startTime = AnalyticsCalculator.formatTime(segment.get(0).getTimeRatio(), duration);
-            double dropRate = AnalyticsCalculator.avgChurnRate(rates);
+            String startTime = calcTime(segment.get(0), duration);
+            double dropRate = calcDropRate(segment);
 
             boolean isLastSegment = (i == SEGMENT_COUNT - 1);
             if (isLastSegment) {
                 dropPoints.add(new DropPoint(startTime, null, dropRate));
             } else {
-                String endTime = AnalyticsCalculator.formatTime(segment.get(SEGMENT_SIZE - 1).getTimeRatio(), duration);
+                String endTime = calcTime(segment.get(SEGMENT_SIZE - 1), duration);
                 dropPoints.add(new DropPoint(startTime, endTime, dropRate));
             }
         }
 
         return new DropPointsResponse(dropPoints);
+    }
+
+    private static double calcDropRate(List<AudienceRetention> segment) {
+        List<Double> rates = segment.stream()
+                .map(AudienceRetention::getRetentionRate)
+                .toList();
+        return AnalyticsCalculator.avgChurnRate(rates);
+    }
+
+    private static String calcTime(AudienceRetention point, Double duration) {
+        return AnalyticsCalculator.formatTime(point.getTimeRatio(), duration);
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/dto/DropPointsResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/DropPointsResponse.java
@@ -1,0 +1,44 @@
+package com.example.inflace.domain.video.dto;
+
+import com.example.inflace.domain.video.domain.AudienceRetention;
+import com.example.inflace.global.util.AnalyticsCalculator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record DropPointsResponse(List<DropPoint> dropPoints) {
+
+    private static final int SEGMENT_SIZE = 25;
+    private static final int SEGMENT_COUNT = 4;
+
+    public record DropPoint(String startTime, String endTime, Double dropRate) {
+    }
+
+    public static DropPointsResponse from(List<AudienceRetention> retentionList, Double duration) {
+        List<DropPoint> dropPoints = new ArrayList<>();
+
+        for (int i = 0; i < SEGMENT_COUNT; i++) {
+            int from = i * SEGMENT_SIZE;
+            int to = from + SEGMENT_SIZE;
+
+            List<AudienceRetention> segment = retentionList.subList(from, to);
+
+            List<Double> rates = segment.stream()
+                    .map(AudienceRetention::getRetentionRate)
+                    .toList();
+
+            String startTime = AnalyticsCalculator.formatTime(segment.get(0).getTimeRatio(), duration);
+            double dropRate = AnalyticsCalculator.avgChurnRate(rates);
+
+            boolean isLastSegment = (i == SEGMENT_COUNT - 1);
+            if (isLastSegment) {
+                dropPoints.add(new DropPoint(startTime, null, dropRate));
+            } else {
+                String endTime = AnalyticsCalculator.formatTime(segment.get(SEGMENT_SIZE - 1).getTimeRatio(), duration);
+                dropPoints.add(new DropPoint(startTime, endTime, dropRate));
+            }
+        }
+
+        return new DropPointsResponse(dropPoints);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -69,6 +69,11 @@ public class VideoService {
 
         validateVideoOwnership(video, email);
 
+        Double duration = video.getDuration();
+        if (duration == null || duration == 0) {
+            throw new ApiException(ErrorDefine.INVALID_ARGUMENT);
+        }
+
         List<AudienceRetention> retentionList = audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(videoId);
         if (retentionList.isEmpty()) {
             throw new ApiException(ErrorDefine.RETENTION_NOT_FOUND);
@@ -77,7 +82,7 @@ public class VideoService {
             throw new ApiException(ErrorDefine.RETENTION_INVALID);
         }
 
-        return DropPointsResponse.from(retentionList, video.getDuration());
+        return DropPointsResponse.from(retentionList, duration);
     }
 
     public RetentionSummaryResponse getRetentionSummary(String email, Long videoId) {

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -73,6 +73,9 @@ public class VideoService {
         if (retentionList.isEmpty()) {
             throw new ApiException(ErrorDefine.RETENTION_NOT_FOUND);
         }
+        if (retentionList.size() != 100) {
+            throw new ApiException(ErrorDefine.RETENTION_INVALID);
+        }
 
         return DropPointsResponse.from(retentionList, video.getDuration());
     }

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -63,6 +63,20 @@ public class VideoService {
         return AudienceRetentionResponse.from(retentionList);
     }
 
+    public DropPointsResponse getDropPoints(String email, Long videoId) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
+
+        validateVideoOwnership(video, email);
+
+        List<AudienceRetention> retentionList = audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(videoId);
+        if (retentionList.isEmpty()) {
+            throw new ApiException(ErrorDefine.RETENTION_NOT_FOUND);
+        }
+
+        return DropPointsResponse.from(retentionList, video.getDuration());
+    }
+
     public RetentionSummaryResponse getRetentionSummary(String email, Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -15,6 +15,7 @@ public enum ErrorDefine {
     VIDEO_NOT_FOUND("VIDEO_404", HttpStatus.NOT_FOUND, "Not Found: Video not found"),
     VIDEO_STATS_NOT_FOUND("VIDEO_STATS_404", HttpStatus.NOT_FOUND, "Not Found: Video Stats not found"),
     RETENTION_NOT_FOUND("RETENTION_404", HttpStatus.NOT_FOUND, "Not Found: Retention not found"),
+    RETENTION_INVALID("RETENTION_400", HttpStatus.BAD_REQUEST, "Bad Request: Retention data must have exactly 100 points"),
 
     CHANNEL_NOT_FOUND("CHANNEL_404", HttpStatus.NOT_FOUND, "Not Found: Channel Not Found");
 

--- a/src/main/java/com/example/inflace/global/util/AnalyticsCalculator.java
+++ b/src/main/java/com/example/inflace/global/util/AnalyticsCalculator.java
@@ -1,6 +1,7 @@
 package com.example.inflace.global.util;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 
@@ -95,5 +96,34 @@ public class AnalyticsCalculator {
      */
     public static double toPercent(double value) {
         return value * 100;
+    }
+
+    /**
+     * 구간 평균 이탈률
+     *
+     * @param retentionRates 구간 내 retentionRate 목록 (25개)
+     * @return 연속 차이(churnRate)의 평균
+     */
+    public static double avgChurnRate(List<Double> retentionRates) {
+        if (retentionRates == null || retentionRates.size() < 2) {
+            return 0.0;
+        }
+        double sum = 0.0;
+        for (int i = 1; i < retentionRates.size(); i++) {
+            sum += churnRate(retentionRates.get(i - 1), retentionRates.get(i));
+        }
+        return sum / (retentionRates.size() - 1);
+    }
+
+    /**
+     * 시간 포맷 변환
+     *
+     * @param timeRatio 0.01 ~ 1.00
+     * @param duration  영상 길이 (초)
+     * @return "m:ss" 형태 문자열
+     */
+    public static String formatTime(double timeRatio, double duration) {
+        int total = (int) Math.round(timeRatio * duration);
+        return String.format("%d:%02d", total / 60, total % 60);
     }
 }

--- a/src/main/java/com/example/inflace/global/util/AnalyticsCalculator.java
+++ b/src/main/java/com/example/inflace/global/util/AnalyticsCalculator.java
@@ -123,6 +123,10 @@ public class AnalyticsCalculator {
      * @return "m:ss" 형태 문자열
      */
     public static String formatTime(double timeRatio, double duration) {
+        if (duration <= 0 || timeRatio < 0) {
+            return "0:00";
+        }
+
         int total = (int) Math.round(timeRatio * duration);
         return String.format("%d:%02d", total / 60, total % 60);
     }

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -92,7 +91,7 @@ class VideoServiceTest {
 
     // 구간별 다른 감소율로 retention 데이터 생성 (dropRate 검증 전용)
     // segmentSteps[i] = i번 구간의 연속 감소량
-    // timeRatio는 이 테스트의 관심사가 아니므로 0.0으로 stub 처리
+    // timeRatio는 이 테스트의 관심사가 아니므로 0.0으로 고정
     private List<AudienceRetention> createRetentionListWithSteps(double[] segmentSteps) {
         double[] segmentStartValues = {80.0, 30.0, 90.0, 15.0};
         List<AudienceRetention> list = new ArrayList<>();
@@ -100,17 +99,12 @@ class VideoServiceTest {
         for (int seg = 0; seg < 4; seg++) {
             double rate = segmentStartValues[seg];
             for (int i = 0; i < 25; i++) {
-                AudienceRetention retention = mock(AudienceRetention.class);
-                given(retention.getRetentionRate()).willReturn(rate);
-                // getTimeRatio()는 구간의 첫(0) 아이템(startTime)과
-                // 마지막이 아닌 구간의 끝(24) 아이템(endTime)에서만 호출됨
-                // 마지막 구간(seg=3)은 endTime 계산 자체를 건너뜀
-                boolean isStart = (i == 0);
-                boolean isEnd = (i == 24 && seg < 3);
-                if (isStart || isEnd) {
-                    given(retention.getTimeRatio()).willReturn(0.0);
-                }
-                list.add(retention);
+                list.add(AudienceRetention.builder()
+                        .video(video)
+                        .retentionRate(rate)
+                        .timeRatio(0.0)
+                        .collectedAt(LocalDateTime.now())
+                        .build());
                 rate -= segmentSteps[seg];
             }
         }

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -226,4 +226,17 @@ class VideoServiceTest {
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_NOT_FOUND);
     }
+
+    @Test
+    void 이탈_구간_조회_retention_데이터_100개_아니면_예외() {
+        // given
+        List<AudienceRetention> incompleteList = retentionList.subList(0, 50);
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(incompleteList);
+
+        // when & then
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_INVALID);
+    }
 }

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -1,0 +1,235 @@
+package com.example.inflace.domain.video.service;
+
+import com.example.inflace.domain.channel.domain.Channel;
+import com.example.inflace.domain.user.domain.User;
+import com.example.inflace.domain.video.domain.AudienceRetention;
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.dto.DropPointsResponse;
+import com.example.inflace.domain.video.repository.AudienceRetentionRepository;
+import com.example.inflace.domain.video.repository.VideoRepository;
+import com.example.inflace.domain.video.repository.VideoStatsRepository;
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class VideoServiceTest {
+
+    @Mock
+    VideoRepository videoRepository;
+
+    @Mock
+    VideoStatsRepository videoStatsRepository;
+
+    @Mock
+    AudienceRetentionRepository audienceRetentionRepository;
+
+    @InjectMocks
+    VideoService videoService;
+
+    private Video video;
+    private List<AudienceRetention> retentionList;
+
+    private static final String OWNER_EMAIL = "owner@test.com";
+    private static final String OTHER_EMAIL = "other@test.com";
+    private static final Long VIDEO_ID = 1L;
+    private static final double DURATION = 600.0; // 10분
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("테스트유저")
+                .email(OWNER_EMAIL)
+                .build();
+
+        Channel channel = Channel.builder()
+                .user(user)
+                .name("테스트채널")
+                .build();
+
+        video = Video.builder()
+                .channel(channel)
+                .title("테스트영상")
+                .duration(DURATION)
+                .publishedAt(LocalDateTime.now().minusDays(30))
+                .build();
+
+        retentionList = createRetentionList();
+    }
+
+    // 100개 retention 데이터 생성 (timeRatio 0.01~1.00, 균등 감소)
+    // setUp()용 - 구간 구분 없이 0.5씩 균등 감소
+    private List<AudienceRetention> createRetentionList() {
+        List<AudienceRetention> list = new ArrayList<>();
+        for (int i = 1; i <= 100; i++) {
+            list.add(AudienceRetention.builder()
+                    .video(video)
+                    .timeRatio(i * 0.01)
+                    .retentionRate(100.0 - (i * 0.5))
+                    .collectedAt(LocalDateTime.now())
+                    .build());
+        }
+        return list;
+    }
+
+    // 구간별 다른 감소율로 retention 데이터 생성 (dropRate 검증 전용)
+    // segmentSteps[i] = i번 구간의 연속 감소량
+    // timeRatio는 이 테스트의 관심사가 아니므로 0.0으로 stub 처리
+    private List<AudienceRetention> createRetentionListWithSteps(double[] segmentSteps) {
+        double[] segmentStartValues = {80.0, 30.0, 90.0, 15.0};
+        List<AudienceRetention> list = new ArrayList<>();
+
+        for (int seg = 0; seg < 4; seg++) {
+            double rate = segmentStartValues[seg];
+            for (int i = 0; i < 25; i++) {
+                AudienceRetention retention = mock(AudienceRetention.class);
+                given(retention.getRetentionRate()).willReturn(rate);
+                // getTimeRatio()는 구간의 첫(0) 아이템(startTime)과
+                // 마지막이 아닌 구간의 끝(24) 아이템(endTime)에서만 호출됨
+                // 마지막 구간(seg=3)은 endTime 계산 자체를 건너뜀
+                boolean isStart = (i == 0);
+                boolean isEnd = (i == 24 && seg < 3);
+                if (isStart || isEnd) {
+                    given(retention.getTimeRatio()).willReturn(0.0);
+                }
+                list.add(retention);
+                rate -= segmentSteps[seg];
+            }
+        }
+        return list;
+    }
+
+    @Test
+    void 이탈_구간_조회_성공_4개_구간_반환() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
+
+        // when
+        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.dropPoints()).hasSize(4);
+    }
+
+    @Test
+    void 이탈_구간_조회_성공_마지막_구간_endTime_null() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
+
+        // when
+        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        DropPointsResponse.DropPoint lastSegment = response.dropPoints().get(3);
+        assertThat(lastSegment.endTime()).isNull();
+    }
+
+    @Test
+    void 이탈_구간_조회_성공_처음_3개_구간_endTime_존재() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
+
+        // when
+        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.dropPoints().get(0).endTime()).isNotNull();
+        assertThat(response.dropPoints().get(1).endTime()).isNotNull();
+        assertThat(response.dropPoints().get(2).endTime()).isNotNull();
+    }
+
+    @Test
+    void 이탈_구간_조회_성공_startTime_오름차순() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
+
+        // when
+        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        // 각 구간의 startTime이 이전 구간보다 뒤여야 함
+        // "m:ss" 문자열 비교 대신 인덱스 기반으로 구간 순서 검증
+        List<DropPointsResponse.DropPoint> dropPoints = response.dropPoints();
+        assertThat(dropPoints.get(0).startTime()).isEqualTo("0:06");  // index 0  → timeRatio 0.01 → 0.01 * 600 = 6s
+        assertThat(dropPoints.get(1).startTime()).isEqualTo("2:36");  // index 25 → timeRatio 0.26 → 0.26 * 600 = 156s
+        assertThat(dropPoints.get(2).startTime()).isEqualTo("5:06");  // index 50 → timeRatio 0.51 → 0.51 * 600 = 306s
+        assertThat(dropPoints.get(3).startTime()).isEqualTo("7:36");  // index 75 → timeRatio 0.76 → 0.76 * 600 = 456s
+    }
+
+    @Test
+    void 이탈_구간_조회_성공_구간별_평균_이탈률_검증() {
+        // given
+        // Segment 1: step 2.0 → avgDropRate = 2.0
+        // Segment 2: step 1.0 → avgDropRate = 1.0
+        // Segment 3: step 3.0 → avgDropRate = 3.0
+        // Segment 4: step 0.5 → avgDropRate = 0.5
+        List<AudienceRetention> customList = createRetentionListWithSteps(new double[]{2.0, 1.0, 3.0, 0.5});
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(customList);
+
+        // when
+        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.dropPoints().get(0).dropRate()).isEqualTo(2.0);
+        assertThat(response.dropPoints().get(1).dropRate()).isEqualTo(1.0);
+        assertThat(response.dropPoints().get(2).dropRate()).isEqualTo(3.0);
+        assertThat(response.dropPoints().get(3).dropRate()).isEqualTo(0.5);
+    }
+
+    @Test
+    void 이탈_구간_조회_영상_없으면_예외() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("error", ErrorDefine.VIDEO_NOT_FOUND);
+    }
+
+    @Test
+    void 이탈_구간_조회_소유자_불일치이면_예외() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+
+        // when & then
+        assertThatThrownBy(() -> videoService.getDropPoints(OTHER_EMAIL, VIDEO_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("error", ErrorDefine.AUTH_FORBIDDEN);
+    }
+
+    @Test
+    void 이탈_구간_조회_retention_데이터_없으면_예외() {
+        // given
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/inflace/global/util/AnalyticsCalculatorTest.java
+++ b/src/test/java/com/example/inflace/global/util/AnalyticsCalculatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
@@ -186,5 +187,92 @@ class AnalyticsCalculatorTest {
     void toPercent_1이면_100반환() {
         double result = AnalyticsCalculator.toPercent(1.0);
         assertThat(result).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("구간 평균 이탈률 - 균등 감소 구간 정상 계산")
+    void avgChurnRate_균등감소_정상계산() {
+        // [10.0, 8.0, 6.0, 4.0] → diffs = [2.0, 2.0, 2.0] → avg = 2.0
+        List<Double> rates = List.of(10.0, 8.0, 6.0, 4.0);
+
+        double result = AnalyticsCalculator.avgChurnRate(rates);
+
+        assertThat(result).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("구간 평균 이탈률 - 원소 2개이면 단일 차이값 반환")
+    void avgChurnRate_원소2개이면_단일차이값반환() {
+        // [10.0, 4.0] → diff = 6.0 → avg = 6.0
+        List<Double> rates = List.of(10.0, 4.0);
+
+        double result = AnalyticsCalculator.avgChurnRate(rates);
+
+        assertThat(result).isEqualTo(6.0);
+    }
+
+    @Test
+    @DisplayName("구간 평균 이탈률 - 반복 시청으로 유지율 증가 시 음수 반환")
+    void avgChurnRate_유지율증가시_음수반환() {
+        // [5.0, 8.0, 6.0] → diffs = [-3.0, 2.0] → avg = -0.5
+        List<Double> rates = List.of(5.0, 8.0, 6.0);
+
+        double result = AnalyticsCalculator.avgChurnRate(rates);
+
+        assertThat(result).isEqualTo(-0.5);
+    }
+
+    @Test
+    @DisplayName("구간 평균 이탈률 - null 리스트이면 0 반환")
+    void avgChurnRate_null이면_0반환() {
+        double result = AnalyticsCalculator.avgChurnRate(null);
+
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("구간 평균 이탈률 - 원소 1개이면 0 반환")
+    void avgChurnRate_원소1개이면_0반환() {
+        List<Double> rates = List.of(10.0);
+
+        double result = AnalyticsCalculator.avgChurnRate(rates);
+
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("시간 포맷 변환 - 분:초 정상 변환")
+    void formatTime_분초_정상변환() {
+        // 0.5 * 600 = 300s → "5:00"
+        String result = AnalyticsCalculator.formatTime(0.5, 600.0);
+
+        assertThat(result).isEqualTo("5:00");
+    }
+
+    @Test
+    @DisplayName("시간 포맷 변환 - 초가 한 자리면 0 패딩")
+    void formatTime_초한자리이면_0패딩() {
+        // 0.01 * 600 = 6s → "0:06"
+        String result = AnalyticsCalculator.formatTime(0.01, 600.0);
+
+        assertThat(result).isEqualTo("0:06");
+    }
+
+    @Test
+    @DisplayName("시간 포맷 변환 - 정확히 분 단위이면 초 00")
+    void formatTime_정확히분단위이면_초00() {
+        // 0.1 * 600 = 60s → "1:00"
+        String result = AnalyticsCalculator.formatTime(0.1, 600.0);
+
+        assertThat(result).isEqualTo("1:00");
+    }
+
+    @Test
+    @DisplayName("시간 포맷 변환 - 반올림 적용")
+    void formatTime_반올림적용() {
+        // 0.25 * 363 = 90.75 → round → 91s → "1:31"
+        String result = AnalyticsCalculator.formatTime(0.25, 363.0);
+
+        assertThat(result).isEqualTo("1:31");
     }
 }


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
---

## comment
<!-- 남길 코멘트 -->

- 이탈률 정보 api를 완성했습니다.
- 이탈률은 현재 다음과 같이 계산됩니다.
  - 1/4 구간을 나누기
  - 1/4 구간 내에서 (t-1) - (t) 차이 구간을 계산해서 평균치로 4구간별 이탈률을 측정
- 계산이 예민하게 되어야 하는 부분이라, 테스트 코드를 넣어두었습니다. 테스트 코드 로직에서 빠진 엣지 케이스가 있는지 확인이 필요합니다.

<img width="395" height="221" alt="image" src="https://github.com/user-attachments/assets/75b23224-ab3b-4100-a859-8f7c8c53d8d7" />

시작 시간에 공간이 있는건, 시간이 100개의 단위로 1%로 넘어오는데 이를 시간으로 변환 > 반올림 하면 3초 정도의 공백이 생긴다고 합니다..겹치지 않게 조정해야 해서 요 부분은 어쩔 수 없는 것 같습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동영상 시청자 이탈 지점 조회 API 추가: 4개 세그먼트별 시작시간·종료시간(마지막 세그먼트는 종료시간 null) 및 세그먼트별 이탈률 제공.
* **버그 픽스 / 유효성 강화**
  * 재생시간 및 리텐션 데이터 유효성 검사 추가(리텐션 포인트 개수 검증 등)과 관련 오류 코드 추가.
* **테스트**
  * 신규 엔드포인트와 분석 유틸리티에 대한 단위 테스트 추가 및 오류 처리 케이스 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->