### PR TITLE
In 155 구독자 분포 대시보드

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -3,6 +3,8 @@ package com.example.inflace.domain.channel.controller;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberDistributionResponse;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
@@ -45,4 +47,19 @@ public interface ChannelApi {
     )
     @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
     BaseResponse<ChannelKpiResponse> getChannelKpi(@PathVariable Long channelId);
+
+    @Operation(
+            summary = "구독자/비구독자 비율",
+            description = "채널의 구독자 조회수와 비구독자 조회수 비율을 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    BaseResponse<ChannelSubscriberPatternResponse> getSubscriberPattern(@PathVariable Long channelId);
+
+    @Operation(
+            summary = "구독자 분포",
+            description = "채널의 국가별, 연령별, 성별 분포를 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    BaseResponse<ChannelSubscriberDistributionResponse> getSubscriberDistribution(@PathVariable Long channelId);
+
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -3,6 +3,7 @@ package com.example.inflace.domain.channel.controller;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberDistributionResponse;
 import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
@@ -55,5 +56,12 @@ public class ChannelController implements ChannelApi{
             @PathVariable Long channelId
     ) {
         return new BaseResponse<>(channelService.getSubscriberPattern(channelId));
+    }
+
+    @GetMapping("/{channelId}/subscriber-distribution")
+    public BaseResponse<ChannelSubscriberDistributionResponse> getSubscriberDistribution(
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>(channelService.getSubscriberDistribution(channelId));
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -48,4 +48,5 @@ public class ChannelController implements ChannelApi{
     ) {
         return new BaseResponse<>(channelService.getChannelKpi(channelId));
     }
+
 }

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -3,6 +3,7 @@ package com.example.inflace.domain.channel.controller;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.response.BaseResponse;
@@ -49,4 +50,10 @@ public class ChannelController implements ChannelApi{
         return new BaseResponse<>(channelService.getChannelKpi(channelId));
     }
 
+    @GetMapping("/{channelId}/subscriber-pattern")
+    public BaseResponse<ChannelSubscriberPatternResponse> getSubscriberPattern(
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>(channelService.getSubscriberPattern(channelId));
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -32,6 +32,9 @@ public class ChannelStats extends BaseEntity {
     @Column(name = "total_view_count")
     private Long totalViewCount;
 
+    @Column(name = "subscriber_view_count")
+    private Long subscriberViewCount;
+
     @Column(name = "avg_engagement_rate")
     private Double avgEngagementRate;
 
@@ -51,12 +54,13 @@ public class ChannelStats extends BaseEntity {
     private LocalDateTime collectedAt;
 
     @Builder
-    public ChannelStats(Channel channel, Long subscriberCount, Long totalViewCount, Double avgEngagementRate,
-                        Map<String, Double> audienceGender, Map<String, Double> audienceAge,
+    public ChannelStats(Channel channel, Long subscriberCount, Long totalViewCount, Long subscriberViewCount,
+                        Double avgEngagementRate, Map<String, Double> audienceGender, Map<String, Double> audienceAge,
                         Map<String, Double> audienceCountry, LocalDateTime collectedAt) {
         this.channel = channel;
         this.subscriberCount = subscriberCount;
         this.totalViewCount = totalViewCount;
+        this.subscriberViewCount = subscriberViewCount;
         this.avgEngagementRate = avgEngagementRate;
         this.audienceGender = audienceGender;
         this.audienceAge = audienceAge;

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelEngagementRateResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelEngagementRateResponse.java
@@ -1,5 +1,7 @@
 package com.example.inflace.domain.channel.dto;
 
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.dto.VideoType;
 import java.util.List;
 
 public record ChannelEngagementRateResponse(
@@ -20,5 +22,15 @@ public record ChannelEngagementRateResponse(
             String contentType,
             Double engagementRate
     ) {
+        public static EngageVideo from(int rank, Video video, double engagementRate) {
+            return new EngageVideo(
+                    rank,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    video.isShort() ? VideoType.SHORT_FORM.name() : VideoType.LONG_FORM.name(),
+                    engagementRate
+            );
+        }
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelKpiResponse.java
@@ -6,4 +6,14 @@ public record ChannelKpiResponse(
         Double avgRetentionRate,
         Double weeklyUploadCount
 ) {
+    public static ChannelKpiResponse from(Long totalViews, Double avgEngagementRate, Double avgRetentionRate,
+                                          Double weeklyUploadCount
+    ) {
+        return new ChannelKpiResponse(
+                totalViews != null ? totalViews : 0L,
+                avgEngagementRate != null ? avgEngagementRate : 0.0,
+                avgRetentionRate != null ? avgRetentionRate : 0.0,
+                weeklyUploadCount != null ? weeklyUploadCount : 0.0
+        );
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelNewSubscriberResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelNewSubscriberResponse.java
@@ -1,5 +1,7 @@
 package com.example.inflace.domain.channel.dto;
 
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.domain.VideoStats;
 import java.util.List;
 
 public record ChannelNewSubscriberResponse(
@@ -15,5 +17,19 @@ public record ChannelNewSubscriberResponse(
             Double newSubscriberRatio,
             Double retentionRate
     ) {
+        public static NewSubscriberVideo from(int rank, Video video, VideoStats stats) {
+            return new NewSubscriberVideo(
+                    rank,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    stats != null ? stats.getViewCount() : 0L,
+                    stats != null ? stats.getSubscribersGained() : 0L,
+                    stats != null && stats.getUnsubscribedViewerPercentage() != null
+                            ? stats.getUnsubscribedViewerPercentage() : 0.0,
+                    stats != null && stats.getAverageViewPercentage() != null
+                            ? stats.getAverageViewPercentage() : 0.0
+            );
+        }
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberDistributionResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberDistributionResponse.java
@@ -103,7 +103,7 @@ public record ChannelSubscriberDistributionResponse(
         }
 
         // ISO 국가 코드를 Locale로 변환해 한글 국가명을 만든다.
-        Locale locale = new Locale("", normalized);
+        Locale locale = Locale.of("",normalized);
         String label = locale.getDisplayCountry(Locale.KOREAN);
         return label.isBlank() ? normalized : label;
     }

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberDistributionResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberDistributionResponse.java
@@ -1,0 +1,115 @@
+package com.example.inflace.domain.channel.dto;
+
+import com.example.inflace.domain.channel.domain.ChannelStats;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public record ChannelSubscriberDistributionResponse(
+        List<DistributionItem> gender,
+        List<DistributionItem> age,
+        List<DistributionItem> country
+) {
+    public record DistributionItem(
+            String label,
+            Double percentage
+    ) {
+    }
+    public static ChannelSubscriberDistributionResponse from(ChannelStats channelStats) {
+        return new ChannelSubscriberDistributionResponse(
+                toItems(channelStats.getAudienceGender(), DistributionType.GENDER),
+                toItems(channelStats.getAudienceAge(), DistributionType.AGE),
+                toCountryItems(channelStats.getAudienceCountry())
+        );
+    }
+
+    private static List<DistributionItem> toItems(Map<String, Double> source, DistributionType type) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<DistributionItem> items = new ArrayList<>();
+        for (Map.Entry<String, Double> entry : source.entrySet()) {
+            items.add(new DistributionItem(
+                    resolveLabel(entry.getKey(), type),
+                    entry.getValue() != null ? entry.getValue() : 0.0
+            ));
+        }
+
+        items.sort(Comparator.comparing(DistributionItem::percentage).reversed());
+        return items;
+    }
+
+    private static List<DistributionItem> toCountryItems(Map<String, Double> source) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<DistributionItem> items = new ArrayList<>();
+        for (Map.Entry<String, Double> entry : source.entrySet()) {
+            String code = entry.getKey();
+            if ("ZZ".equalsIgnoreCase(code)) {
+                code = "OTHERS";
+            }
+
+            items.add(new DistributionItem(
+                    resolveCountryLabel(code),
+                    entry.getValue() != null ? entry.getValue() : 0.0
+            ));
+        }
+
+        items.sort(Comparator.comparing(DistributionItem::percentage).reversed());
+
+        if (items.size() <= 5) {
+            return items;
+        }
+
+        List<DistributionItem> topItems = new ArrayList<>(items.subList(0, 4));
+        double othersPercentage = 0.0;
+
+        for (int i = 4; i < items.size(); i++) {
+            othersPercentage += items.get(i).percentage();
+        }
+
+        topItems.add(new DistributionItem("기타", othersPercentage));
+
+        return topItems;
+    }
+
+    private static String resolveLabel(String code, DistributionType type) {
+        if (type == DistributionType.GENDER) {
+            if ("male".equalsIgnoreCase(code)) {
+                return "남성";
+            }
+            if ("female".equalsIgnoreCase(code)) {
+                return "여성";
+            }
+        }
+
+        return code;
+    }
+
+    private static String resolveCountryLabel(String code) {
+        if (code == null || code.isBlank()) {
+            return "기타";
+        }
+
+        String normalized = code.toUpperCase(Locale.ROOT);
+        if ("OTHERS".equals(normalized) || "ZZ".equals(normalized)) {
+            return "기타";
+        }
+
+        // ISO 국가 코드를 Locale로 변환해 한글 국가명을 만든다.
+        Locale locale = new Locale("", normalized);
+        String label = locale.getDisplayCountry(Locale.KOREAN);
+        return label.isBlank() ? normalized : label;
+    }
+
+    private enum DistributionType {
+        GENDER,
+        AGE
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberPatternResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberPatternResponse.java
@@ -1,0 +1,33 @@
+package com.example.inflace.domain.channel.dto;
+
+public record ChannelSubscriberPatternResponse(
+        NewSubscriber newSubscriber
+) {
+    public record NewSubscriber(
+            Long count,
+            Double ratio
+    ) {
+    }
+    public static ChannelSubscriberPatternResponse from(Long totalViewCount, Long subscriberViewCount) {
+        long totalViews = totalViewCount != null ? totalViewCount : 0L;
+        long subscribedViews = subscriberViewCount != null ? subscriberViewCount : 0L;
+
+        if (subscribedViews > totalViews) {
+            subscribedViews = totalViews;
+        }
+
+        long newViews = Math.max(totalViews - subscribedViews, 0L);
+        double newRatio = calculatePercentage(newViews, totalViews);
+
+        return new ChannelSubscriberPatternResponse(
+                new NewSubscriber(newViews, newRatio)
+        );
+    }
+
+    private static double calculatePercentage(long value, long total) {
+        if (total == 0L) {
+            return 0.0;
+        }
+        return (value * 100.0) / total;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberPatternResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelSubscriberPatternResponse.java
@@ -1,9 +1,9 @@
 package com.example.inflace.domain.channel.dto;
 
 public record ChannelSubscriberPatternResponse(
-        NewSubscriber newSubscriber
+        ChannelSubscriberViewRatio subscriberRatio
 ) {
-    public record NewSubscriber(
+    public record  ChannelSubscriberViewRatio(
             Long count,
             Double ratio
     ) {
@@ -20,7 +20,7 @@ public record ChannelSubscriberPatternResponse(
         double newRatio = calculatePercentage(newViews, totalViews);
 
         return new ChannelSubscriberPatternResponse(
-                new NewSubscriber(newViews, newRatio)
+                new ChannelSubscriberViewRatio(newViews, newRatio)
         );
     }
 

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopVideosResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopVideosResponse.java
@@ -1,5 +1,7 @@
 package com.example.inflace.domain.channel.dto;
 
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.domain.VideoStats;
 import java.util.List;
 
 public record ChannelTopVideosResponse(
@@ -15,5 +17,18 @@ public record ChannelTopVideosResponse(
             Double ctr,
             Double retentionRate
     ){
+        public static ChannelTopVideo from(int rank, Video video, VideoStats videoStats) {
+            return new ChannelTopVideo(
+                    rank,
+                    video.getId(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    videoStats != null ? videoStats.getViewCount() : 0L,
+                    video.getRisingScore() != null ? video.getRisingScore() : 0.0,
+                    videoStats != null && videoStats.getCtr() != null ? videoStats.getCtr() : 0.0,
+                    videoStats != null && videoStats.getAverageViewPercentage() != null
+                            ? videoStats.getAverageViewPercentage() : 0.0
+            );
+        }
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -5,6 +5,7 @@ import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse.NewSubscriberVideo;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberDistributionResponse;
 import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
@@ -133,6 +134,16 @@ public class ChannelService {
                 channelStats.getTotalViewCount(),
                 channelStats.getSubscriberViewCount()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ChannelSubscriberDistributionResponse getSubscriberDistribution(Long channelId) {
+        validateChannelExists(channelId);
+
+        ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
+
+        return ChannelSubscriberDistributionResponse.from(channelStats);
     }
 
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -5,6 +5,7 @@ import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse.NewSubscriberVideo;
+import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.channel.repository.ChannelStatsRepository;
@@ -120,6 +121,20 @@ public class ChannelService {
                 weeklyUploadCount
         );
     }
+
+    @Transactional(readOnly = true)
+    public ChannelSubscriberPatternResponse getSubscriberPattern(Long channelId) {
+        validateChannelExists(channelId);
+
+        ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
+
+        return ChannelSubscriberPatternResponse.from(
+                channelStats.getTotalViewCount(),
+                channelStats.getSubscriberViewCount()
+        );
+    }
+
 
     private void validateChannelExists(Long channelId) {
         if (!channelRepository.existsById(channelId)) {

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -92,19 +92,7 @@ public class ChannelService {
         int rank = 1;
         for (Video video : videos) {
             VideoStats videoStats = videoStatsMap.get(video.getId());
-
-            items.add(new NewSubscriberVideo(
-                    rank,
-                    video.getId(),
-                    video.getTitle(),
-                    video.getThumbnailUrl(),
-                    videoStats != null ? videoStats.getViewCount() : 0L,
-                    videoStats != null ? videoStats.getSubscribersGained() : 0L,
-                    videoStats != null && videoStats.getUnsubscribedViewerPercentage() != null
-                            ? videoStats.getUnsubscribedViewerPercentage() : 0.0,
-                    videoStats != null && videoStats.getAverageViewPercentage() != null
-                            ? videoStats.getAverageViewPercentage() : 0.0
-            ));
+            items.add(ChannelNewSubscriberResponse.NewSubscriberVideo.from(rank, video, videoStats));
             rank++;
         }
 
@@ -125,9 +113,9 @@ public class ChannelService {
         Long recentUploadCount = videoRepository.countByChannelIdAndPublishedAtGreaterThanEqual(channelId, oneMonthAgo);
         double weeklyUploadCount = Math.round((recentUploadCount / (30.0 / 7.0)) * 100) / 100.0;
 
-        return new ChannelKpiResponse(
-                channelStats.getTotalViewCount() != null ? channelStats.getTotalViewCount() : 0L,
-                channelStats.getAvgEngagementRate() != null ? channelStats.getAvgEngagementRate() : 0.0,
+        return ChannelKpiResponse.from(
+                channelStats.getTotalViewCount(),
+                channelStats.getAvgEngagementRate(),
                 calculateAverageRetentionRate(videos, videoStatsMap),
                 weeklyUploadCount
         );
@@ -164,19 +152,7 @@ public class ChannelService {
 
         for (Video video : videos) {
             VideoStats videoStats = videoStatsMap.get(video.getId());
-
-            items.add(new ChannelTopVideosResponse.ChannelTopVideo(
-                    rank,
-                    video.getId(),
-                    video.getTitle(),
-                    video.getThumbnailUrl(),
-                    videoStats != null ? videoStats.getViewCount() : 0L,
-                    video.getRisingScore() != null ? video.getRisingScore() : 0.0,
-                    videoStats != null && videoStats.getCtr() != null ? videoStats.getCtr() : 0.0,
-                    videoStats != null && videoStats.getAverageViewPercentage() != null
-                            ? videoStats.getAverageViewPercentage() : 0.0
-            ));
-
+            items.add(ChannelTopVideosResponse.ChannelTopVideo.from(rank, video, videoStats));
             rank++;
         }
 
@@ -213,7 +189,7 @@ public class ChannelService {
 
     //참여율 항목 만들기
     private List<ChannelEngagementRateResponse.EngageVideo> mapEngagementRateItems(List<Video> videos, Map<Long, VideoStats> videoStatsMap) {
-        List<ChannelEngagementRateResponse.EngageVideo> items = new ArrayList<>();
+        List<EngagementRateItem> items = new ArrayList<>();
 
         for (Video video : videos) {
             VideoStats videoStats = videoStatsMap.get(video.getId());
@@ -221,12 +197,8 @@ public class ChannelService {
                 continue;
             }
 
-            items.add(new ChannelEngagementRateResponse.EngageVideo(
-                    0,
-                    video.getId(),
-                    video.getTitle(),
-                    video.getThumbnailUrl(),
-                    video.isShort() ? VideoType.SHORT_FORM.name() : VideoType.LONG_FORM.name(),
+            items.add(new EngagementRateItem(
+                    video,
                     AnalyticsCalculator.engagementRate(
                             videoStats.getLikeCount(),
                             videoStats.getCommentCount(),
@@ -240,28 +212,31 @@ public class ChannelService {
             if (compareEngagementRate != 0) {
                 return compareEngagementRate;
             }
-            return Long.compare(item2.videoId(), item1.videoId());
+            return Long.compare(item2.video().getId(), item1.video().getId());
         });
 
         List<ChannelEngagementRateResponse.EngageVideo> rankedItems = new ArrayList<>();
         int rank = 1;
-        for (ChannelEngagementRateResponse.EngageVideo item : items) {
+        for (EngagementRateItem item : items) {
             if (rank > 5) {
                 break;
             }
 
-            rankedItems.add(new ChannelEngagementRateResponse.EngageVideo(
+            rankedItems.add(ChannelEngagementRateResponse.EngageVideo.from(
                     rank,
-                    item.videoId(),
-                    item.title(),
-                    item.thumbnailUrl(),
-                    item.contentType(),
+                    item.video(),
                     item.engagementRate()
             ));
             rank++;
         }
 
         return rankedItems;
+    }
+
+    private record EngagementRateItem(
+            Video video,
+            double engagementRate
+    ) {
     }
 
     //채널 참여율 평균 구하기


### PR DESCRIPTION
##  Issue
closed #41 

---

## comment
구독자 분포 대시보드, 구독/비구독자 조회수 비율 api를 구현하였습니다
+ 구독/비구독자 조회수 비율을 쉽게 계산하기 위해 채널통계 테이블에 구독자 조회수를 추가하였습니다.
<img width="329" height="436" alt="image" src="https://github.com/user-attachments/assets/25f3f50b-8170-41c3-8b0b-4cbad721a683" />
<img width="328" height="198" alt="image" src="https://github.com/user-attachments/assets/b93da8f6-801e-44ad-b4eb-87b63ae45858" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채널의 구독자 조회 패턴을 분석할 수 있는 새로운 API 엔드포인트 추가
  * 구독자의 성별, 연령대, 국가별 분포 통계를 조회할 수 있는 새로운 API 엔드포인트 추가

* **Improvements**
  * 채널 통계 데이터 모델 개선으로 더욱 정확한 구독자 분석 데이터 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->