### PR TITLE
feat: 메인 top5 비디오 api 완료

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -3,17 +3,26 @@ package com.example.inflace.domain.channel.controller;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelTopMainVideosResponse;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Channel", description = "채널 관련 API")
 public interface ChannelApi {
+
+    @Operation(
+            summary = "에픽 2-1, 메인 인기 영상 Top 5",
+            description = "쇼츠/일반 구분 없이 채널의 인기 Top 5 영상을 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
+    BaseResponse<ChannelTopMainVideosResponse> getMainTopVideos(@AuthenticationPrincipal String email, @PathVariable Long channelId);
 
     @Operation(
             summary = "인기 급상승 영상 Top 5",

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -4,6 +4,7 @@ import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
 
+import com.example.inflace.domain.channel.dto.ChannelTopMainVideosResponse;
 import com.example.inflace.domain.channel.dto.ChannelSubscriberDistributionResponse;
 import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -3,10 +3,12 @@ package com.example.inflace.domain.channel.controller;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
+import com.example.inflace.domain.channel.dto.ChannelTopMainVideosResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
 import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChannelController implements ChannelApi{
 
     private final ChannelService channelService;
+
+    @GetMapping("/{channelId}/main/tops")
+    public BaseResponse<ChannelTopMainVideosResponse> getMainTopVideos(
+            @AuthenticationPrincipal String email,
+            @PathVariable Long channelId
+    ) {
+        return new BaseResponse<>(channelService.getMainTopVideos(email, channelId));
+    }
 
     @GetMapping("/{channelId}/tops")
     public BaseResponse<ChannelTopVideosResponse> getTopVideos(

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopMainVideosResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelTopMainVideosResponse.java
@@ -1,0 +1,46 @@
+package com.example.inflace.domain.channel.dto;
+
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.domain.VideoStats;
+import com.example.inflace.global.util.AnalyticsCalculator;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+public record ChannelTopMainVideosResponse(
+        List<ChannelTopMainVideo> videos
+) {
+    public record ChannelTopMainVideo(
+            Long rank,
+            Long videoId,
+            String title,
+            String thumbnailUrl,
+            Long viewCount,
+            Long likeCount,
+            Long commentCount,
+            Double engagementRate,
+            LocalDateTime publishedAt,
+            Double ctr
+    ) {
+        public static ChannelTopMainVideo of(long rank, Video video, VideoStats stats) {
+            long viewCount = 0L;
+            long likeCount = 0L;
+            long commentCount = 0L;
+            double ctr = 0.0;
+            double engagementRate = 0.0;
+
+            if (stats != null) {
+                viewCount = Objects.requireNonNullElse(stats.getViewCount(), 0L);
+                likeCount = Objects.requireNonNullElse(stats.getLikeCount(), 0L);
+                commentCount = Objects.requireNonNullElse(stats.getCommentCount(), 0L);
+                ctr = Objects.requireNonNullElse(stats.getCtr(), 0.0);
+                engagementRate = AnalyticsCalculator.engagementRate(
+                        stats.getLikeCount(), stats.getCommentCount(), stats.getViewCount());
+            }
+
+            return new ChannelTopMainVideo(rank, video.getId(), video.getTitle(), video.getThumbnailUrl(),
+                    viewCount, likeCount, commentCount, engagementRate, video.getPublishedAt(), ctr);
+        }
+    }
+}

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -1,6 +1,8 @@
 package com.example.inflace.domain.channel.service;
 
+import com.example.inflace.domain.channel.domain.Channel;
 import com.example.inflace.domain.channel.domain.ChannelStats;
+import com.example.inflace.domain.channel.dto.ChannelTopMainVideosResponse;
 import com.example.inflace.domain.channel.dto.ChannelEngagementRateResponse;
 import com.example.inflace.domain.channel.dto.ChannelKpiResponse;
 import com.example.inflace.domain.channel.dto.ChannelNewSubscriberResponse;
@@ -19,6 +21,7 @@ import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.util.AnalyticsCalculator;
 import java.time.LocalDateTime;
+import org.springframework.data.domain.Limit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -131,6 +134,33 @@ public class ChannelService {
                 calculateAverageRetentionRate(videos, videoStatsMap),
                 weeklyUploadCount
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ChannelTopMainVideosResponse getMainTopVideos(String email, Long channelId) {
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+
+        validateChannelOwnership(channel, email);
+
+        List<Video> videos = videoRepository.findAllTopVideos(channelId, Limit.of(5));
+        Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
+        List<ChannelTopMainVideosResponse.ChannelTopMainVideo> items = new ArrayList<>();
+        long rank = 1;
+
+        for (Video video : videos) {
+            items.add(ChannelTopMainVideosResponse.ChannelTopMainVideo.of(rank, video, videoStatsMap.get(video.getId())));
+            rank++;
+        }
+
+        return new ChannelTopMainVideosResponse(items);
+    }
+
+    // TODO : 차후 email이 아닌 sub 기반으로 변경
+    private void validateChannelOwnership(Channel channel, String email) {
+        if (!channel.getUser().getEmail().equals(email)) {
+            throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
+        }
     }
 
     private void validateChannelExists(Long channelId) {

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoRepository.java
@@ -3,6 +3,7 @@ package com.example.inflace.domain.video.repository;
 import com.example.inflace.domain.video.domain.Video;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -34,6 +35,15 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             @Param("channelId") Long channelId,
             Pageable pageable
     );
+
+    @Query("""
+            select v
+            from Video v
+            left join VideoStats vs on vs.video = v
+            where v.channel.id = :channelId
+            order by coalesce(v.risingScore, 0) desc, coalesce(vs.ctr, 0) desc, v.id desc
+            """)
+    List<Video> findAllTopVideos(@Param("channelId") Long channelId, Limit limit);
 
     Long countByChannelIdAndPublishedAtGreaterThanEqual(Long channelId, LocalDateTime publishedAt);
 


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #45 

---

## comment
<!-- 남길 코멘트 -->

- 에픽 2-1 메인 화면의 인기 영상 top5 api를 만들었습니다.
- 원래 h2 db 붙여서 쿼리 검증 테스트 하려고 했는데 TEXT[]가 H2에 없는 postgre 오리지널 문법이라 테스트가 깨져서 지웠습니다ㅠ이건 차차 해결책을 생각해보겠습니다.

<img width="707" height="301" alt="image" src="https://github.com/user-attachments/assets/e8968223-a747-4aca-a8b5-6111396f263b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 채널 상위 영상 조회 기능이 추가되었습니다. 조회수, 좋아요, 댓글 수 등 상세한 참여도 지표를 포함하여 채널의 인기 영상 목록을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->