### PR TITLE
fix: 로그인 메서드 전부 id 기반으로 변경

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -9,6 +9,7 @@ import com.example.inflace.domain.channel.dto.ChannelSubscriberDistributionRespo
 import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
+import com.example.inflace.global.config.AuthUser;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.response.BaseResponse;
@@ -26,7 +27,7 @@ public interface ChannelApi {
             description = "쇼츠/일반 구분 없이 채널의 인기 Top 5 영상을 조회합니다."
     )
     @ApiErrorDefines({ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
-    BaseResponse<ChannelTopMainVideosResponse> getMainTopVideos(@AuthenticationPrincipal String email, @PathVariable Long channelId);
+    BaseResponse<ChannelTopMainVideosResponse> getMainTopVideos(@AuthenticationPrincipal AuthUser authUser, @PathVariable Long channelId);
 
     @Operation(
             summary = "인기 급상승 영상 Top 5",

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -11,6 +11,7 @@ import com.example.inflace.domain.channel.dto.ChannelSubscriberPatternResponse;
 
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.dto.ChannelTopVideosResponse;
+import com.example.inflace.global.config.AuthUser;
 import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,10 +30,10 @@ public class ChannelController implements ChannelApi{
 
     @GetMapping("/{channelId}/main/tops")
     public BaseResponse<ChannelTopMainVideosResponse> getMainTopVideos(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long channelId
     ) {
-        return new BaseResponse<>(channelService.getMainTopVideos(email, channelId));
+        return new BaseResponse<>(channelService.getMainTopVideos(authUser.userId(), channelId));
     }
 
     @GetMapping("/{channelId}/tops")

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -127,11 +127,11 @@ public class ChannelService {
     }
 
     @Transactional(readOnly = true)
-    public ChannelTopMainVideosResponse getMainTopVideos(String email, Long channelId) {
+    public ChannelTopMainVideosResponse getMainTopVideos(long userId, Long channelId) {
         Channel channel = channelRepository.findById(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
 
-        validateChannelOwnership(channel, email);
+        validateChannelOwnership(channel, userId);
 
         List<Video> videos = videoRepository.findAllTopVideos(channelId, Limit.of(5));
         Map<Long, VideoStats> videoStatsMap = getVideoStatsMap(videos);
@@ -146,9 +146,8 @@ public class ChannelService {
         return new ChannelTopMainVideosResponse(items);
     }
 
-    // TODO : 차후 email이 아닌 sub 기반으로 변경
-    private void validateChannelOwnership(Channel channel, String email) {
-        if (!channel.getUser().getEmail().equals(email)) {
+    private void validateChannelOwnership(Channel channel, long userId) {
+        if (channel.getUser().getId() != userId) {
             throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
         }
     }

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -5,6 +5,7 @@ import com.example.inflace.domain.video.dto.DropPointsResponse;
 import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
+import com.example.inflace.global.config.AuthUser;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.response.BaseResponse;
@@ -21,7 +22,7 @@ public interface VideoApi {
                     "썸네일, 제목, 설명, 해시태그 등을 반환합니다."
     )
     @ApiErrorDefines(ErrorDefine.VIDEO_NOT_FOUND)
-    BaseResponse<VideoMetaResponse> getVideoMeta(@AuthenticationPrincipal String email,
+    BaseResponse<VideoMetaResponse> getVideoMeta(@AuthenticationPrincipal AuthUser authUser,
                                                  @PathVariable("videoId") Long videoId);
 
     @Operation(
@@ -31,7 +32,7 @@ public interface VideoApi {
                     "DB에 데이터가 없을 경우 YouTube Analytics API를 호출하여 저장 후 반환합니다."
     )
     @ApiErrorDefines(ErrorDefine.VIDEO_NOT_FOUND)
-    BaseResponse<VideoStatsResponse> getVideoStats(@AuthenticationPrincipal String email,
+    BaseResponse<VideoStatsResponse> getVideoStats(@AuthenticationPrincipal AuthUser authUser,
                                                    @PathVariable("videoId") Long videoId);
 
     @Operation(
@@ -40,7 +41,7 @@ public interface VideoApi {
                     "0.01~1.00 구간의 100개 포인트를 반환합니다."
     )
     @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
-    BaseResponse<AudienceRetentionResponse> getRetention(@AuthenticationPrincipal String email,
+    BaseResponse<AudienceRetentionResponse> getRetention(@AuthenticationPrincipal AuthUser authUser,
                                                          @PathVariable("videoId") Long videoId);
 
     @Operation(
@@ -49,7 +50,7 @@ public interface VideoApi {
                     "100개의 시청 지속률 데이터를 25개씩 4구간으로 나눠 각 구간의 평균 이탈률을 반환합니다."
     )
     @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.RETENTION_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.RETENTION_INVALID, ErrorDefine.INVALID_ARGUMENT})
-    BaseResponse<DropPointsResponse> getDropPoints(@AuthenticationPrincipal String email,
+    BaseResponse<DropPointsResponse> getDropPoints(@AuthenticationPrincipal AuthUser authUser,
                                                    @PathVariable("videoId") Long videoId);
 
     @Operation(
@@ -58,6 +59,6 @@ public interface VideoApi {
                     "평균 시청 지속 시간(초)과 평균 대비 유지율을 반환합니다."
     )
     @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.VIDEO_STATS_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
-    BaseResponse<RetentionSummaryResponse> getRetentionSummary(@AuthenticationPrincipal String email,
+    BaseResponse<RetentionSummaryResponse> getRetentionSummary(@AuthenticationPrincipal AuthUser authUser,
                                                                @PathVariable("videoId") Long videoId);
 }

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoController.java
@@ -6,6 +6,7 @@ import com.example.inflace.domain.video.dto.RetentionSummaryResponse;
 import com.example.inflace.domain.video.dto.VideoMetaResponse;
 import com.example.inflace.domain.video.dto.VideoStatsResponse;
 import com.example.inflace.domain.video.service.VideoService;
+import com.example.inflace.global.config.AuthUser;
 import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,50 +22,50 @@ public class VideoController implements VideoApi {
     @Override
     @GetMapping("/{videoId}")
     public BaseResponse<VideoMetaResponse> getVideoMeta(
-            @AuthenticationPrincipal String email,  // 현재 jwt에 저장되는 컨텍스트가 이메일
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long videoId
     ) {
-        VideoMetaResponse response = videoService.getVideoMeta(email, videoId);
+        VideoMetaResponse response = videoService.getVideoMeta(authUser.userId(), videoId);
         return new BaseResponse<>(response);
     }
 
     @Override
     @GetMapping("/{videoId}/stats")
     public BaseResponse<VideoStatsResponse> getVideoStats(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long videoId
     ) {
-        VideoStatsResponse response = videoService.getVideoStats(email, videoId);
+        VideoStatsResponse response = videoService.getVideoStats(authUser.userId(), videoId);
         return new BaseResponse<>(response);
     }
 
     @Override
     @GetMapping("/{videoId}/retention")
     public BaseResponse<AudienceRetentionResponse> getRetention(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long videoId
     ) {
-        AudienceRetentionResponse response = videoService.getRetention(email, videoId);
+        AudienceRetentionResponse response = videoService.getRetention(authUser.userId(), videoId);
         return new BaseResponse<>(response);
     }
 
     @Override
     @GetMapping("/{videoId}/retention/drop-points")
     public BaseResponse<DropPointsResponse> getDropPoints(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long videoId
     ) {
-        DropPointsResponse response = videoService.getDropPoints(email, videoId);
+        DropPointsResponse response = videoService.getDropPoints(authUser.userId(), videoId);
         return new BaseResponse<>(response);
     }
 
     @Override
     @GetMapping("/{videoId}/retention/summary")
     public BaseResponse<RetentionSummaryResponse> getRetentionSummary(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long videoId
     ) {
-        RetentionSummaryResponse response = videoService.getRetentionSummary(email, videoId);
+        RetentionSummaryResponse response = videoService.getRetentionSummary(authUser.userId(), videoId);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -24,23 +24,23 @@ public class VideoService {
     private final VideoStatsRepository videoStatsRepository;
     private final AudienceRetentionRepository audienceRetentionRepository;
 
-    public VideoMetaResponse getVideoMeta(String email, Long videoId) {
+    public VideoMetaResponse getVideoMeta(long userId, Long videoId) {
         // 영상 목록에서 클릭 후 이동, 외부 API 필요하지 않음
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
 
         // 소유자 확인
-        validateVideoOwnership(video, email);
+        validateVideoOwnership(video, userId);
 
         return VideoMetaResponse.from(video);
     }
 
-    public VideoStatsResponse getVideoStats(String email, Long videoId) {
+    public VideoStatsResponse getVideoStats(long userId, Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
 
         // 소유자 확인
-        validateVideoOwnership(video, email);
+        validateVideoOwnership(video, userId);
 
         VideoStats videoStats = videoStatsRepository.findByVideo(video)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_STATS_NOT_FOUND));
@@ -48,12 +48,12 @@ public class VideoService {
         return VideoStatsResponse.from(videoStats, 0L, 0L);
     }
 
-    public AudienceRetentionResponse getRetention(String email, Long videoId) {
+    public AudienceRetentionResponse getRetention(long userId, Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
 
         // 소유자 확인
-        validateVideoOwnership(video, email);
+        validateVideoOwnership(video, userId);
 
         List<AudienceRetention> retentionList = audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(videoId);
         if (retentionList.isEmpty()) {
@@ -63,11 +63,11 @@ public class VideoService {
         return AudienceRetentionResponse.from(retentionList);
     }
 
-    public DropPointsResponse getDropPoints(String email, Long videoId) {
+    public DropPointsResponse getDropPoints(long userId, Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
 
-        validateVideoOwnership(video, email);
+        validateVideoOwnership(video, userId);
 
         Double duration = video.getDuration();
         if (duration == null || duration == 0) {
@@ -85,11 +85,11 @@ public class VideoService {
         return DropPointsResponse.from(retentionList, duration);
     }
 
-    public RetentionSummaryResponse getRetentionSummary(String email, Long videoId) {
+    public RetentionSummaryResponse getRetentionSummary(long userId, Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_NOT_FOUND));
 
-        validateVideoOwnership(video, email);
+        validateVideoOwnership(video, userId);
 
         VideoStats videoStats = videoStatsRepository.findByVideo(video)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_STATS_NOT_FOUND));
@@ -97,9 +97,8 @@ public class VideoService {
         return RetentionSummaryResponse.from(videoStats);
     }
 
-    private void validateVideoOwnership(Video video, String email) {
-        String ownerEmail = video.getChannel().getUser().getEmail();
-        if (!ownerEmail.equals(email)) {
+    private void validateVideoOwnership(Video video, long userId) {
+        if (video.getChannel().getUser().getId() != userId) {
             throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
         }
     }

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -1,7 +1,7 @@
 package com.example.inflace.domain.video.service;
 
 import com.example.inflace.domain.channel.domain.Channel;
-import com.example.inflace.domain.user.domain.User;
+import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.domain.video.domain.AudienceRetention;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.dto.DropPointsResponse;
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -47,8 +48,8 @@ class VideoServiceTest {
     private Video video;
     private List<AudienceRetention> retentionList;
 
-    private static final String OWNER_EMAIL = "owner@test.com";
-    private static final String OTHER_EMAIL = "other@test.com";
+    private static final long OWNER_USER_ID = 1L;
+    private static final long OTHER_USER_ID = 2L;
     private static final Long VIDEO_ID = 1L;
     private static final double DURATION = 600.0; // 10분
 
@@ -56,8 +57,8 @@ class VideoServiceTest {
     void setUp() {
         User user = User.builder()
                 .name("테스트유저")
-                .email(OWNER_EMAIL)
                 .build();
+        ReflectionTestUtils.setField(user, "id", OWNER_USER_ID);
 
         Channel channel = Channel.builder()
                 .user(user)
@@ -118,7 +119,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
 
         // when
-        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+        DropPointsResponse response = videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.dropPoints()).hasSize(4);
@@ -131,7 +132,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
 
         // when
-        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+        DropPointsResponse response = videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID);
 
         // then
         DropPointsResponse.DropPoint lastSegment = response.dropPoints().get(3);
@@ -145,7 +146,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
 
         // when
-        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+        DropPointsResponse response = videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.dropPoints().get(0).endTime()).isNotNull();
@@ -160,7 +161,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(retentionList);
 
         // when
-        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+        DropPointsResponse response = videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID);
 
         // then
         // 각 구간의 startTime이 이전 구간보다 뒤여야 함
@@ -184,7 +185,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(customList);
 
         // when
-        DropPointsResponse response = videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID);
+        DropPointsResponse response = videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.dropPoints().get(0).dropRate()).isEqualTo(2.0);
@@ -199,7 +200,7 @@ class VideoServiceTest {
         given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.VIDEO_NOT_FOUND);
     }
@@ -210,7 +211,7 @@ class VideoServiceTest {
         given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
 
         // when & then
-        assertThatThrownBy(() -> videoService.getDropPoints(OTHER_EMAIL, VIDEO_ID))
+        assertThatThrownBy(() -> videoService.getDropPoints(OTHER_USER_ID, VIDEO_ID))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.AUTH_FORBIDDEN);
     }
@@ -222,7 +223,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(List.of());
 
         // when & then
-        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_NOT_FOUND);
     }
@@ -235,7 +236,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(incompleteList);
 
         // when & then
-        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
+        assertThatThrownBy(() -> videoService.getDropPoints(OWNER_USER_ID, VIDEO_ID))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_INVALID);
     }


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #49 

---

## comment
<!-- 남길 코멘트 -->

- 로그인 sub 변경에 따라 기존에 email 기반이던 것을 AuthUser (userId) 기반으로 변경하였습니다!
- 기능 동작 문제 없는 것 확인하였습니다. 간단한 수정이라 바로 합치겠습니다!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 채널 및 비디오 API의 인증 처리 방식을 개선하여 더 강력한 타입 안전성 제공
  * 내부 서비스 로직 최적화로 신뢰성 향상

* **테스트**
  * 업데이트된 인증 처리 방식에 맞춰 테스트 케이스 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->