### PR TITLE
In 156 2 4 급하락 구간 api에 추가

### DIFF
--- a/src/main/java/com/example/inflace/domain/video/dto/AudienceRetentionResponse.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/AudienceRetentionResponse.java
@@ -1,7 +1,9 @@
 package com.example.inflace.domain.video.dto;
 
 import com.example.inflace.domain.video.domain.AudienceRetention;
+import com.example.inflace.global.util.AnalyticsCalculator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public record AudienceRetentionResponse(
@@ -9,14 +11,21 @@ public record AudienceRetentionResponse(
 ) {
     public record RetentionData(
             Double timeRatio,
-            Double watchRatio
+            Double watchRatio,
+            String displayTime,
+            Boolean isDrop
     ) {
     }
 
-    public static AudienceRetentionResponse from(List<AudienceRetention> retentionList) {
-        List<RetentionData> data = retentionList.stream()
-                .map(r -> new RetentionData(r.getTimeRatio(), r.getRetentionRate()))
-                .toList();
+    public static AudienceRetentionResponse from(List<AudienceRetention> retentionList, double duration) {
+        List<RetentionData> data = new ArrayList<>();
+        for (int i = 0; i < retentionList.size(); i++) {
+            AudienceRetention r = retentionList.get(i);
+            String displayTime = AnalyticsCalculator.formatTime(r.getTimeRatio(), duration);
+            boolean isDrop = i > 0 &&
+                    retentionList.get(i - 1).getRetentionRate() - r.getRetentionRate() >= 0.05;
+            data.add(new RetentionData(r.getTimeRatio(), r.getRetentionRate(), displayTime, isDrop));
+        }
         return new AudienceRetentionResponse(data);
     }
 }

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -60,7 +60,8 @@ public class VideoService {
             throw new ApiException(ErrorDefine.RETENTION_NOT_FOUND);
         }
 
-        return AudienceRetentionResponse.from(retentionList);
+        double duration = video.getDuration() != null ? video.getDuration() : 0.0;
+        return AudienceRetentionResponse.from(retentionList, duration);
     }
 
     public DropPointsResponse getDropPoints(String email, Long videoId) {

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -1,9 +1,10 @@
 package com.example.inflace.domain.video.service;
 
 import com.example.inflace.domain.channel.domain.Channel;
-import com.example.inflace.domain.user.domain.User;
+import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.domain.video.domain.AudienceRetention;
 import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.dto.AudienceRetentionResponse;
 import com.example.inflace.domain.video.dto.DropPointsResponse;
 import com.example.inflace.domain.video.repository.AudienceRetentionRepository;
 import com.example.inflace.domain.video.repository.VideoRepository;
@@ -238,5 +239,76 @@ class VideoServiceTest {
         assertThatThrownBy(() -> videoService.getDropPoints(OWNER_EMAIL, VIDEO_ID))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("error", ErrorDefine.RETENTION_INVALID);
+    }
+
+    @Test
+    void 시청_지속률_조회_성공_감소량_0_05_이상이면_isDrop_true() {
+        // given - 차이 0.06 (>= 0.05)
+        List<AudienceRetention> list = List.of(
+                AudienceRetention.builder().video(video).timeRatio(0.01).retentionRate(90.0).collectedAt(LocalDateTime.now()).build(),
+                AudienceRetention.builder().video(video).timeRatio(0.02).retentionRate(89.94).collectedAt(LocalDateTime.now()).build()
+        );
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
+
+        // when
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.retentionData().get(1).isDrop()).isTrue();
+    }
+
+    @Test
+    void 시청_지속률_조회_성공_감소량_0_05_미만이면_isDrop_false() {
+        // given - 차이 0.03 (< 0.05)
+        List<AudienceRetention> list = List.of(
+                AudienceRetention.builder().video(video).timeRatio(0.01).retentionRate(90.0).collectedAt(LocalDateTime.now()).build(),
+                AudienceRetention.builder().video(video).timeRatio(0.02).retentionRate(89.97).collectedAt(LocalDateTime.now()).build()
+        );
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
+
+        // when
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.retentionData().get(1).isDrop()).isFalse();
+    }
+
+    @Test
+    void 시청_지속률_조회_성공_displayTime이_올바른_MM_SS_형식으로_반환() {
+        // given - timeRatio 0.5 * duration 600.0 = 300s → "5:00"
+        List<AudienceRetention> list = List.of(
+                AudienceRetention.builder().video(video).timeRatio(0.5).retentionRate(80.0).collectedAt(LocalDateTime.now()).build()
+        );
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(video));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
+
+        // when
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.retentionData().get(0).displayTime()).isEqualTo("5:00");
+    }
+
+    @Test
+    void 시청_지속률_조회_duration_null이면_displayTime이_0_00_반환() {
+        // given - duration이 null인 영상
+        Video videoWithNullDuration = Video.builder()
+                .channel(video.getChannel())
+                .title("duration없는영상")
+                .publishedAt(LocalDateTime.now().minusDays(1))
+                .build();
+        List<AudienceRetention> list = List.of(
+                AudienceRetention.builder().video(videoWithNullDuration).timeRatio(0.5).retentionRate(80.0).collectedAt(LocalDateTime.now()).build()
+        );
+        given(videoRepository.findById(VIDEO_ID)).willReturn(Optional.of(videoWithNullDuration));
+        given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
+
+        // when
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+
+        // then
+        assertThat(response.retentionData().get(0).displayTime()).isEqualTo("0:00");
     }
 }

--- a/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
+++ b/src/test/java/com/example/inflace/domain/video/service/VideoServiceTest.java
@@ -253,7 +253,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
 
         // when
-        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.retentionData().get(1).isDrop()).isTrue();
@@ -270,7 +270,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
 
         // when
-        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.retentionData().get(1).isDrop()).isFalse();
@@ -286,7 +286,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
 
         // when
-        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.retentionData().get(0).displayTime()).isEqualTo("5:00");
@@ -307,7 +307,7 @@ class VideoServiceTest {
         given(audienceRetentionRepository.findByVideoIdOrderByTimeRatioAsc(VIDEO_ID)).willReturn(list);
 
         // when
-        AudienceRetentionResponse response = videoService.getRetention(OWNER_EMAIL, VIDEO_ID);
+        AudienceRetentionResponse response = videoService.getRetention(OWNER_USER_ID, VIDEO_ID);
 
         // then
         assertThat(response.retentionData().get(0).displayTime()).isEqualTo("0:00");


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #48 

---

## comment
<!-- 남길 코멘트 -->

- 말풍선 호버시 사용하는 급하락 구간을 api에 추가했습니다.
- 기획에서 나왔던 내용 대로 다음과 같이, 이전 대비 5% 떨어졌다면 isDrop이 true로 표시되어 이를 통해 프론트에서 표현 가능합니다.
- 이 부분 계산 로직이라 test code가 필요할 것 같아서 추가했고, 통과 확인했습니다!
- 마찬가지로 약간의 필드 추가만 한거라 코드 래빗 리뷰 후 바로 머지하겠습니다.

<img width="364" height="302" alt="image" src="https://github.com/user-attachments/assets/a0d6de21-643d-4e20-8299-1e9dd6522c9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시청자 유지율에 분:초 형식의 표시시간 추가(예: 5:00).
  * 시청자 유지율에서 급격한 감소 지점(isDrop)을 자동 감지하는 지표 추가(감소 임계값 적용).
  * 영상 길이 정보가 없을 경우 표시시간을 0:00으로 처리.

* **테스트**
  * 표시시간 형식 및 감소 감지 동작을 검증하는 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->