### PR TITLE
feat: 연동 여부 확인 api 완성

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
@@ -4,4 +4,5 @@ import com.example.inflace.domain.channel.domain.Channel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelRepository extends JpaRepository<Channel, Long> {
+    boolean existsByUser_Id(long userId);
 }

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -1,8 +1,10 @@
 package com.example.inflace.domain.user.application;
 
+import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.user.infra.UserCommandRepository;
 import com.example.inflace.domain.user.infra.UserReadRepository;
 import com.example.inflace.domain.user.presentation.OnboardingRequest;
+import com.example.inflace.domain.user.presentation.YoutubeLinkedResponse;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +17,16 @@ public class UserService {
 
     private final UserReadRepository userReadRepository;
     private final UserCommandRepository userCommandRepository;
+    private final ChannelRepository channelRepository;
 
     @Transactional
     public long registerIfNotExists(String sub, String name, String email, String profileImage) {
         return userCommandRepository.insertIfNotExists(sub, name, email, profileImage);
+    }
+
+    @Transactional(readOnly = true)
+    public YoutubeLinkedResponse isYoutubeLinked(long userId) {
+        return new YoutubeLinkedResponse(channelRepository.existsByUser_Id(userId));
     }
 
     @Transactional

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
@@ -1,0 +1,29 @@
+package com.example.inflace.domain.user.presentation;
+
+import com.example.inflace.global.config.AuthUser;
+import com.example.inflace.global.exception.ApiErrorDefines;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User", description = "유저 API")
+public interface UserApi {
+
+    @Operation(
+            summary = "온보딩",
+            description = "유저 역할과 필요 항목을 저장합니다."
+    )
+    ResponseEntity<BaseResponse> onboarding(@AuthenticationPrincipal AuthUser authUser,
+                                            @RequestBody OnboardingRequest request);
+
+    @Operation(
+            summary = "에픽 2-1, 유튜브 채널 연동 여부 조회",
+            description = "현재 로그인한 유저의 유튜브 채널 연동 여부를 반환합니다."
+    )
+    @ApiErrorDefines(ErrorDefine.AUTH_FORBIDDEN)
+    BaseResponse<YoutubeLinkedResponse> getYoutubeLinkedStatus(@AuthenticationPrincipal AuthUser authUser);
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -2,10 +2,13 @@ package com.example.inflace.domain.user.presentation;
 
 import com.example.inflace.domain.user.application.UserService;
 import com.example.inflace.global.config.AuthUser;
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,15 +17,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApi {
 
     private final UserService userService;
 
+    @Override
     @PostMapping("/onboarding")
     public ResponseEntity<BaseResponse> onboarding(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestBody OnboardingRequest request) {
         userService.onboarding(authUser.userId(), request);
         return ResponseEntity.ok(BaseResponse.success());
+    }
+
+    @Override
+    @GetMapping("/youtube/linked")
+    public BaseResponse<YoutubeLinkedResponse> getYoutubeLinkedStatus(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        if (authUser == null) {
+            throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
+        }
+        return new BaseResponse<>(userService.isYoutubeLinked(authUser.userId()));
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/YoutubeLinkedResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/YoutubeLinkedResponse.java
@@ -1,0 +1,4 @@
+package com.example.inflace.domain.user.presentation;
+
+public record YoutubeLinkedResponse(boolean isLinked) {
+}


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #52 

---

## comment
<!-- 남길 코멘트 -->

- 처음 main 화면에 들어왔을때, 채널 연동 전 후 화면이 달라서 채널 연동 여부를 간단하게 체킹할 수 있는 api를 만들었습니다.
- 원래 google oauth 기반으로 할까 하다가...현재 redis와 같은 외부 서버 기반 디비가 붙어있는게 아니고 인메모리에 map으로 저장하는 형태라, 서버 재시작하면 날라가기 때문에 channel 엔티티안에 해당 유저의 정보가 있는지를 여부로 판단합니다.
- 이 부분은 차후 필요시 정책 바꿔주셔도 될 것 같습니다.

<img width="356" height="160" alt="image" src="https://github.com/user-attachments/assets/15e00c61-0388-4549-acb7-881b383c45d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * YouTube 계정 연동 상태 조회 기능을 추가했습니다. 인증된 사용자는 자신의 YouTube 계정 연동 여부를 확인할 수 있습니다. 계정 연동 상태는 명확한 응답 형식으로 제공되며, 미인증 사용자의 접근에 대해서는 적절한 보안 오류 처리를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->