### PR TITLE
feat: 내 채널 정보 구현 완료

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
@@ -2,11 +2,13 @@ package com.example.inflace.domain.channel.domain;
 
 import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.global.entity.BaseEntity;
+import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 
@@ -29,17 +31,23 @@ public class Channel extends BaseEntity {
     @Column(name = "youtube_channel_id")
     private String youtubeChannelId;
 
-    private String category;
+    @Type(value = StringArrayType.class)
+    @Column(name = "category", columnDefinition = "text[]")
+    private String[] category;
+
+    @Column(name = "channel_handle")
+    private String channelHandle;
 
     @Column(name = "entered_at")
     private LocalDateTime enteredAt;
 
     @Builder
-    public Channel(User user, String name, String youtubeChannelId, String category, LocalDateTime enteredAt) {
+    public Channel(User user, String name, String youtubeChannelId, String[] category, String channelHandle, LocalDateTime enteredAt) {
         this.user = user;
         this.name = name;
         this.youtubeChannelId = youtubeChannelId;
         this.category = category;
+        this.channelHandle = channelHandle;
         this.enteredAt = enteredAt;
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
@@ -3,6 +3,9 @@ package com.example.inflace.domain.channel.repository;
 import com.example.inflace.domain.channel.domain.Channel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChannelRepository extends JpaRepository<Channel, Long> {
     boolean existsByUser_Id(long userId);
+    Optional<Channel> findByUser_Id(long userId);
 }

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -1,23 +1,36 @@
 package com.example.inflace.domain.user.application;
 
+import com.example.inflace.domain.channel.domain.Channel;
+import com.example.inflace.domain.channel.domain.ChannelStats;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
+import com.example.inflace.domain.channel.repository.ChannelStatsRepository;
+import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.domain.user.infra.UserCommandRepository;
 import com.example.inflace.domain.user.infra.UserReadRepository;
 import com.example.inflace.domain.user.presentation.OnboardingRequest;
+import com.example.inflace.domain.user.presentation.UserChannelMainResponse;
 import com.example.inflace.domain.user.presentation.YoutubeLinkedResponse;
+import com.example.inflace.domain.video.domain.Video;
+import com.example.inflace.domain.video.repository.VideoRepository;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private static final String YOUTUBE_STUDIO_URL_PREFIX = "https://studio.youtube.com/channel/";
 
     private final UserReadRepository userReadRepository;
     private final UserCommandRepository userCommandRepository;
     private final ChannelRepository channelRepository;
+    private final ChannelStatsRepository channelStatsRepository;
+    private final VideoRepository videoRepository;
 
     @Transactional
     public long registerIfNotExists(String sub, String name, String email, String profileImage) {
@@ -27,6 +40,36 @@ public class UserService {
     @Transactional(readOnly = true)
     public YoutubeLinkedResponse isYoutubeLinked(long userId) {
         return new YoutubeLinkedResponse(channelRepository.existsByUser_Id(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public UserChannelMainResponse getMainChannelInfo(long userId) {
+        User user = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        Channel channel = channelRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+
+        ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channel.getId())
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
+
+        List<Video> videos = videoRepository.findByChannelId(channel.getId());
+
+        List<String> category = channel.getCategory() != null
+                ? Arrays.asList(channel.getCategory())
+                : null;
+
+        return new UserChannelMainResponse(
+                user.getProfileImage(),
+                channel.getName(),
+                YOUTUBE_STUDIO_URL_PREFIX + channel.getYoutubeChannelId(),
+                channel.getChannelHandle(),
+                category,
+                channel.getEnteredAt(),
+                channelStats.getSubscriberCount(),
+                (long) videos.size(),
+                channel.getUpdatedAt()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
@@ -26,4 +26,11 @@ public interface UserApi {
     )
     @ApiErrorDefines(ErrorDefine.AUTH_FORBIDDEN)
     BaseResponse<YoutubeLinkedResponse> getYoutubeLinkedStatus(@AuthenticationPrincipal AuthUser authUser);
+
+    @Operation(
+            summary = "에픽 2-1, 유저 채널 메인 정보 조회",
+            description = "유저 본인의 YouTube 채널 기본 정보를 반환합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.USER_NOT_FOUND, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    BaseResponse<UserChannelMainResponse> getUserChannelMain(@AuthenticationPrincipal AuthUser authUser);
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserChannelMainResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserChannelMainResponse.java
@@ -1,0 +1,17 @@
+package com.example.inflace.domain.user.presentation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UserChannelMainResponse(
+        String profileImageUrl,
+        String name,
+        String youtubeStudioUrl,
+        String channelHandle,
+        List<String> category,
+        LocalDateTime enteredAt,
+        Long subscriberCount,
+        Long videoCount,
+        LocalDateTime latestUploadDate
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -40,4 +40,15 @@ public class UserController implements UserApi {
         }
         return new BaseResponse<>(userService.isYoutubeLinked(authUser.userId()));
     }
+
+    @Override
+    @GetMapping("/channels/main")
+    public BaseResponse<UserChannelMainResponse> getUserChannelMain(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        if (authUser == null) {
+            throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
+        }
+        return new BaseResponse<>(userService.getMainChannelInfo(authUser.userId()));
+    }
 }

--- a/src/main/java/com/example/inflace/domain/video/domain/Video.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/Video.java
@@ -46,6 +46,10 @@ public class Video extends BaseEntity {
     @Column(name = "hashtags", columnDefinition = "text[]")
     private String[] hashtags;
 
+    @Type(value = StringArrayType.class)
+    @Column(name = "category", columnDefinition = "text[]")
+    private String[] category;
+
     @Column(name = "youtube_video_id")
     private String youtubeVideoId;
 
@@ -56,7 +60,7 @@ public class Video extends BaseEntity {
 
     @Builder
     public Video(Channel channel, String title, String thumbnailUrl, Double duration, boolean isShort, Double risingScore,
-                 LocalDateTime publishedAt, String[] hashtags, String youtubeVideoId, String videoUrl, String description) {
+                 LocalDateTime publishedAt, String[] hashtags, String[] category, String youtubeVideoId, String videoUrl, String description) {
         this.channel = channel;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
@@ -65,6 +69,7 @@ public class Video extends BaseEntity {
         this.risingScore = risingScore;
         this.publishedAt = publishedAt;
         this.hashtags = hashtags;
+        this.category = category;
         this.youtubeVideoId = youtubeVideoId;
         this.videoUrl = videoUrl;
         this.description = description;


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

closed #54 

---

## comment
<!-- 남길 코멘트 -->

- 에픽 2-1, 2-2 상단에 쓰이는 내 채널 정보 조회 api 입니다.
- 현재 카테고리 정책이 video에서 top3개 카테고리 > channel에 적용이라 channel의 category가 text[] 타입으로 바뀌었고, video의 category가 text[]로 추가되었습니다. 참고 부탁드립니다.

<img width="384" height="229" alt="image" src="https://github.com/user-attachments/assets/1d0a65b8-b0b6-45ed-a29d-485139015f4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**신기능**
- 채널 주요 정보 조회 엔드포인트 추가: 프로필 이미지, 채널 이름, 핸들, 카테고리, 구독자 수, 영상 개수, 최신 업로드 날짜 및 YouTube 스튜디오 링크를 한 번에 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->