### PR TITLE
feat: 구글에서 유튜브 연동, JWT 페이로드 추가

### DIFF
--- a/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/GoogleLoginStrategy.java
@@ -19,6 +19,6 @@ public class GoogleLoginStrategy implements OAuthLoginStrategy {
         GoogleTokenResponse token = googleApiClient.getToken(code);
         GoogleUserInfoResponse userInfo = googleApiClient.getUserInfo(token.accessToken());
 
-        return new OAuthUserInfo(userInfo.sub(), userInfo.name(), userInfo.email(), userInfo.picture(), Plan.FREE);
+        return new OAuthUserInfo(userInfo.sub(), userInfo.name(), userInfo.email(), userInfo.picture(), Plan.FREE, token.accessToken());
     }
 }

--- a/src/main/java/com/example/inflace/domain/auth/application/YoutubeLoginStrategy.java
+++ b/src/main/java/com/example/inflace/domain/auth/application/YoutubeLoginStrategy.java
@@ -3,7 +3,6 @@ package com.example.inflace.domain.auth.application;
 import com.example.inflace.domain.auth.presentation.dto.GoogleTokenResponse;
 import com.example.inflace.domain.auth.presentation.dto.GoogleUserInfoResponse;
 import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
-import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
 import com.example.inflace.domain.user.domain.enums.Plan;
 import com.example.inflace.global.client.GoogleApiClient;
 import com.example.inflace.global.properties.YoutubeProperties;
@@ -15,15 +14,13 @@ import org.springframework.stereotype.Component;
 public class YoutubeLoginStrategy implements OAuthLoginStrategy {
 
     private final GoogleApiClient googleApiClient;
-    private final GoogleAccessTokenStore googleAccessTokenStore;
     private final YoutubeProperties youtubeProperties;
 
     @Override
     public OAuthUserInfo getUserInfo(String code) {
         GoogleTokenResponse token = googleApiClient.getToken(code, youtubeProperties.oauth().redirectUri());
         GoogleUserInfoResponse userInfo = googleApiClient.getUserInfo(token.accessToken());
-        googleAccessTokenStore.save(userInfo.email(), token.accessToken());
 
-        return new OAuthUserInfo(userInfo.sub(), userInfo.name(), userInfo.email(), userInfo.picture(), Plan.FREE);
+        return new OAuthUserInfo(userInfo.sub(), userInfo.name(), userInfo.email(), userInfo.picture(), Plan.FREE, token.accessToken());
     }
 }

--- a/src/main/java/com/example/inflace/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/com/example/inflace/domain/auth/facade/AuthFacade.java
@@ -3,7 +3,10 @@ package com.example.inflace.domain.auth.facade;
 import com.example.inflace.domain.auth.application.OAuthStrategyRouter;
 import com.example.inflace.domain.auth.presentation.dto.OAuthUserInfo;
 import com.example.inflace.domain.auth.presentation.dto.TokenData;
+import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
 import com.example.inflace.domain.auth.util.RefreshTokenStore;
+import com.example.inflace.domain.channel.domain.Channel;
+import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.user.application.UserService;
 import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.domain.user.infra.UserReadRepository;
@@ -14,6 +17,8 @@ import com.example.inflace.global.exception.ErrorDefine;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AuthFacade {
@@ -23,6 +28,8 @@ public class AuthFacade {
     private final UserReadRepository userReadRepository;
     private final JwtProvider jwtProvider;
     private final RefreshTokenStore refreshTokenStore;
+    private final GoogleAccessTokenStore googleAccessTokenStore;
+    private final ChannelRepository channelRepository;
 
     public TokenData login(String provider, String code) {
         OAuthUserInfo userInfo = oAuthStrategyRouter.getStrategy(provider).getUserInfo(code);
@@ -35,15 +42,25 @@ public class AuthFacade {
                 userInfo.plan()
         );
 
+        User user = userReadRepository.findById(result.userId())
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        Optional<Channel> channelOpt = channelRepository.findByUser_Id(result.userId());
         String accessToken = jwtProvider.createAccessToken(
                 result.userId(),
                 userInfo.picture(),
-                result.isNewUser(),
-                userInfo.plan()
+                userInfo.plan(),
+                channelOpt.map(Channel::getName).orElse(null),
+                channelOpt.map(Channel::getProfileImage).orElse(null),
+                user.isOnboardingCompleted()
         );
         String refreshToken = jwtProvider.createRefreshToken(result.userId());
 
         refreshTokenStore.save(result.userId(), refreshToken);
+
+        if (userInfo.accessToken() != null) {
+            googleAccessTokenStore.save(result.userId(), userInfo.accessToken());
+        }
 
         return new TokenData(accessToken, refreshToken);
     }
@@ -67,7 +84,15 @@ public class AuthFacade {
                 .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
 
 
-        String newAccessToken = jwtProvider.createAccessToken(userId, user.getProfileImage(), false, user.getPlan());
+        Optional<Channel> channelOpt = channelRepository.findByUser_Id(userId);
+        String newAccessToken = jwtProvider.createAccessToken(
+                userId,
+                user.getProfileImage(),
+                user.getPlan(),
+                channelOpt.map(Channel::getName).orElse(null),
+                channelOpt.map(Channel::getProfileImage).orElse(null),
+                user.isOnboardingCompleted()
+        );
         String newRefreshToken = jwtProvider.createRefreshToken(userId);
         refreshTokenStore.save(userId, newRefreshToken);
 

--- a/src/main/java/com/example/inflace/domain/auth/presentation/dto/OAuthUserInfo.java
+++ b/src/main/java/com/example/inflace/domain/auth/presentation/dto/OAuthUserInfo.java
@@ -7,6 +7,7 @@ public record OAuthUserInfo(
         String name,
         String email,
         String picture,
-        Plan plan
+        Plan plan,
+        String accessToken
 ) {
 }

--- a/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
+++ b/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
@@ -9,14 +9,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class GoogleAccessTokenStore {
-    private final Map<String, String> tokenStore = new ConcurrentHashMap<>();
+    private final Map<Long, String> tokenStore = new ConcurrentHashMap<>();
 
-    public void save(String googleId, String accessToken) {
-        tokenStore.put(googleId, accessToken);
+    public void save(long userId, String accessToken) {
+        tokenStore.put(userId, accessToken);
     }
 
-    public String getAccessToken(String googleId) {
-        String token = tokenStore.get(googleId);
+    public String getAccessToken(long userId) {
+        String token = tokenStore.get(userId);
         if (token == null) {
             throw new ApiException(ErrorDefine.INVALID_HEADER_ERROR);
         }

--- a/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
@@ -59,4 +59,13 @@ public class Channel extends BaseEntity {
         this.name = name;
         this.profileImage = profileImage;
     }
+
+    public void updateAll(String name, String profileImage, String youtubeChannelId, String channelHandle, String[] category, LocalDateTime enteredAt) {
+        this.name = name;
+        this.profileImage = profileImage;
+        this.youtubeChannelId = youtubeChannelId;
+        this.channelHandle = channelHandle;
+        this.category = category;
+        this.enteredAt = enteredAt;
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/Channel.java
@@ -38,16 +38,25 @@ public class Channel extends BaseEntity {
     @Column(name = "channel_handle")
     private String channelHandle;
 
+    @Column(name = "profile_image")
+    private String profileImage;
+
     @Column(name = "entered_at")
     private LocalDateTime enteredAt;
 
     @Builder
-    public Channel(User user, String name, String youtubeChannelId, String[] category, String channelHandle, LocalDateTime enteredAt) {
+    public Channel(User user, String name, String youtubeChannelId, String[] category, String channelHandle, String profileImage, LocalDateTime enteredAt) {
         this.user = user;
         this.name = name;
         this.youtubeChannelId = youtubeChannelId;
         this.category = category;
         this.channelHandle = channelHandle;
+        this.profileImage = profileImage;
         this.enteredAt = enteredAt;
+    }
+
+    public void updateProfile(String name, String profileImage) {
+        this.name = name;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -67,4 +67,10 @@ public class ChannelStats extends BaseEntity {
         this.audienceCountry = audienceCountry;
         this.collectedAt = collectedAt;
     }
+
+    public void updateBasicStats(Long subscriberCount, Long totalViewCount, LocalDateTime collectedAt) {
+        this.subscriberCount = subscriberCount;
+        this.totalViewCount = totalViewCount;
+        this.collectedAt = collectedAt;
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -73,4 +73,18 @@ public class ChannelStats extends BaseEntity {
         this.totalViewCount = totalViewCount;
         this.collectedAt = collectedAt;
     }
+
+    public void updateAnalyticsStats(
+            Long subscriberViewCount,
+            Double avgEngagementRate,
+            Map<String, Double> audienceGender,
+            Map<String, Double> audienceAge,
+            Map<String, Double> audienceCountry
+    ) {
+        this.subscriberViewCount = subscriberViewCount;
+        this.avgEngagementRate = avgEngagementRate;
+        this.audienceGender = audienceGender;
+        this.audienceAge = audienceAge;
+        this.audienceCountry = audienceCountry;
+    }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/YoutubeDataChannelResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/YoutubeDataChannelResponse.java
@@ -8,10 +8,15 @@ public record YoutubeDataChannelResponse(
     public record Item(
             String id,
             Snippet snippet,
-            Statistics statistics
+            Statistics statistics,
+            TopicDetails topicDetails
+    ){}
+    public record TopicDetails(
+            List<String> topicCategories
     ){}
     public record Snippet(
             String title,
+            String customUrl,
             String publishedAt,
             String country,
             Thumbnails thumbnails

--- a/src/main/java/com/example/inflace/domain/channel/dto/YoutubeDataChannelResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/YoutubeDataChannelResponse.java
@@ -13,7 +13,14 @@ public record YoutubeDataChannelResponse(
     public record Snippet(
             String title,
             String publishedAt,
-            String country
+            String country,
+            Thumbnails thumbnails
+    ){}
+    public record Thumbnails(
+            ThumbnailUrl high
+    ){}
+    public record ThumbnailUrl(
+            String url
     ){}
     public record Statistics(
        String subscriberCount,

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -25,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -106,17 +109,51 @@ public class UserService {
         YoutubeDataChannelResponse.Item item = channelResponse.items().get(0);
         String channelName = item.snippet().title();
         String profileImage = item.snippet().thumbnails().high().url();
+        String youtubeChannelId = item.id();
+        String channelHandle = item.snippet().customUrl();
+        LocalDateTime enteredAt = item.snippet().publishedAt() != null
+                ? LocalDateTime.ofInstant(Instant.parse(item.snippet().publishedAt()), ZoneOffset.UTC)
+                : null;
+        Long subscriberCount = item.statistics() != null && item.statistics().subscriberCount() != null
+                ? Long.parseLong(item.statistics().subscriberCount())
+                : null;
+        Long totalViewCount = item.statistics() != null && item.statistics().viewCount() != null
+                ? Long.parseLong(item.statistics().viewCount())
+                : null;
+        String[] categories = item.topicDetails() != null && item.topicDetails().topicCategories() != null
+                ? item.topicDetails().topicCategories().stream()
+                        .map(url -> url.substring(url.lastIndexOf('/') + 1).replace('_', ' '))
+                        .toArray(String[]::new)
+                : null;
 
         Optional<Channel> existingChannel = channelRepository.findByUser_Id(userId);
+        Channel channel;
         if (existingChannel.isPresent()) {
-            existingChannel.get().updateProfile(channelName, profileImage);
+            channel = existingChannel.get();
+            channel.updateAll(channelName, profileImage, youtubeChannelId, channelHandle, categories, enteredAt);
         } else {
             User user = userReadRepository.findById(userId)
                     .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
-            channelRepository.save(Channel.builder()
+            channel = channelRepository.save(Channel.builder()
                     .user(user)
                     .name(channelName)
                     .profileImage(profileImage)
+                    .youtubeChannelId(youtubeChannelId)
+                    .channelHandle(channelHandle)
+                    .category(categories)
+                    .enteredAt(enteredAt)
+                    .build());
+        }
+
+        Optional<ChannelStats> existingStats = channelStatsRepository.findByChannel_Id(channel.getId());
+        if (existingStats.isPresent()) {
+            existingStats.get().updateBasicStats(subscriberCount, totalViewCount, LocalDateTime.now());
+        } else {
+            channelStatsRepository.save(ChannelStats.builder()
+                    .channel(channel)
+                    .subscriberCount(subscriberCount)
+                    .totalViewCount(totalViewCount)
+                    .collectedAt(LocalDateTime.now())
                     .build());
         }
 

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -4,6 +4,7 @@ import com.example.inflace.domain.channel.domain.Channel;
 import com.example.inflace.domain.channel.domain.ChannelStats;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.channel.repository.ChannelStatsRepository;
+import com.example.inflace.domain.channel.dto.YoutubeDataChannelResponse;
 import com.example.inflace.domain.user.domain.entity.User;
 import com.example.inflace.domain.user.domain.enums.Plan;
 import com.example.inflace.domain.user.infra.UserCommandRepository;
@@ -11,9 +12,13 @@ import com.example.inflace.domain.user.infra.UserReadRepository;
 import com.example.inflace.domain.user.infra.UserRegistrationResult;
 import com.example.inflace.domain.user.presentation.OnboardingRequest;
 import com.example.inflace.domain.user.presentation.UserChannelMainResponse;
+import com.example.inflace.domain.user.presentation.YoutubeChannelLinkResponse;
 import com.example.inflace.domain.user.presentation.YoutubeLinkedResponse;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.repository.VideoRepository;
+import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
+import com.example.inflace.global.client.YoutubeDataApiClient;
+import com.example.inflace.global.config.JwtProvider;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +39,9 @@ public class UserService {
     private final ChannelRepository channelRepository;
     private final ChannelStatsRepository channelStatsRepository;
     private final VideoRepository videoRepository;
+    private final GoogleAccessTokenStore googleAccessTokenStore;
+    private final YoutubeDataApiClient youtubeDataApiClient;
+    private final JwtProvider jwtProvider;
 
     @Transactional
     public UserRegistrationResult registerIfNotExists(String sub, String name, String email, String profileImage, Plan plan) {
@@ -83,6 +92,50 @@ public class UserService {
     }
 
     @Transactional
+    public YoutubeChannelLinkResponse linkYoutubeChannel(long userId) {
+        String accessToken = googleAccessTokenStore.getAccessToken(userId);
+        if (accessToken == null) {
+            throw new ApiException(ErrorDefine.YOUTUBE_TOKEN_NOT_FOUND);
+        }
+        YoutubeDataChannelResponse channelResponse = youtubeDataApiClient.getMyChannel(accessToken);
+
+        if (channelResponse.items() == null || channelResponse.items().isEmpty()) {
+            throw new ApiException(ErrorDefine.YOUTUBE_CHANNEL_NOT_FOUND);
+        }
+
+        YoutubeDataChannelResponse.Item item = channelResponse.items().get(0);
+        String channelName = item.snippet().title();
+        String profileImage = item.snippet().thumbnails().high().url();
+
+        Optional<Channel> existingChannel = channelRepository.findByUser_Id(userId);
+        if (existingChannel.isPresent()) {
+            existingChannel.get().updateProfile(channelName, profileImage);
+        } else {
+            User user = userReadRepository.findById(userId)
+                    .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+            channelRepository.save(Channel.builder()
+                    .user(user)
+                    .name(channelName)
+                    .profileImage(profileImage)
+                    .build());
+        }
+
+        User updatedUser = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        String newAccessToken = jwtProvider.createAccessToken(
+                userId,
+                updatedUser.getProfileImage(),
+                updatedUser.getPlan(),
+                channelName,
+                profileImage,
+                updatedUser.isOnboardingCompleted()
+        );
+
+        return new YoutubeChannelLinkResponse(channelName, profileImage, newAccessToken);
+    }
+
+    @Transactional
     public void onboarding(long userId, OnboardingRequest request) {
 
         if (request.role() == null || request.need() == null || request.need().isEmpty()) {
@@ -91,5 +144,6 @@ public class UserService {
 
         userCommandRepository.insertUserType(userId, request.role().name());
         userCommandRepository.bulkInsertNeeds(userId, request.need());
+        userCommandRepository.updateOnboardingCompleted(userId);
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -17,21 +17,28 @@ import com.example.inflace.domain.user.presentation.YoutubeLinkedResponse;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.repository.VideoRepository;
 import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
+import com.example.inflace.domain.video.dto.YoutubeAnalyticsVideoRequest;
 import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.config.JwtProvider;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.service.YoutubeAnalyticsService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -44,6 +51,7 @@ public class UserService {
     private final VideoRepository videoRepository;
     private final GoogleAccessTokenStore googleAccessTokenStore;
     private final YoutubeDataApiClient youtubeDataApiClient;
+    private final YoutubeAnalyticsService youtubeAnalyticsService;
     private final JwtProvider jwtProvider;
 
     @Transactional
@@ -156,6 +164,96 @@ public class UserService {
                     .collectedAt(LocalDateTime.now())
                     .build());
         }
+
+        // Analytics API로 추가 채널 통계 수집 (각 항목 독립 수집)
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(28);
+
+        Long subscriberViewCount = null;
+        Double avgEngagementRate = null;
+        Map<String, Double> audienceGender = null;
+        Map<String, Double> audienceAge = null;
+        Map<String, Double> audienceCountry = null;
+
+        try {
+            Map<String, Object> subscriberViewData = youtubeAnalyticsService.query(userId,
+                    new YoutubeAnalyticsVideoRequest(startDate, endDate,
+                            List.of("views"), null, null, "subscribedStatus==SUBSCRIBED"));
+            if (!subscriberViewData.isEmpty()) {
+                subscriberViewCount = ((Number) subscriberViewData.get("views")).longValue();
+            }
+        } catch (Exception e) {
+            log.warn("구독자 조회수 수집 실패 (데이터 부족 또는 API 오류): userId={}, error={}", userId, e.getMessage());
+        }
+
+        try {
+            Map<String, Object> engagementData = youtubeAnalyticsService.query(userId,
+                    new YoutubeAnalyticsVideoRequest(startDate, endDate,
+                            List.of("views", "likes", "comments", "shares"), null, null, null));
+            if (!engagementData.isEmpty()) {
+                double views = ((Number) engagementData.get("views")).doubleValue();
+                double likes = ((Number) engagementData.getOrDefault("likes", 0)).doubleValue();
+                double comments = ((Number) engagementData.getOrDefault("comments", 0)).doubleValue();
+                double shares = ((Number) engagementData.getOrDefault("shares", 0)).doubleValue();
+                if (views > 0) {
+                    avgEngagementRate = (likes + comments + shares) / views * 100;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("평균 참여율 수집 실패 (데이터 부족 또는 API 오류): userId={}, error={}", userId, e.getMessage());
+        }
+
+        try {
+            List<Map<String, Object>> genderRows = youtubeAnalyticsService.queryAllRows(userId,
+                    new YoutubeAnalyticsVideoRequest(startDate, endDate,
+                            List.of("viewerPercentage"), null, "gender", null));
+            if (!genderRows.isEmpty()) {
+                Map<String, Double> genderMap = new HashMap<>();
+                for (Map<String, Object> row : genderRows) {
+                    genderMap.put((String) row.get("gender"),
+                            ((Number) row.get("viewerPercentage")).doubleValue());
+                }
+                audienceGender = genderMap;
+            }
+        } catch (Exception e) {
+            log.warn("성별 분포 수집 실패 (시청자 데이터 부족 또는 API 오류): userId={}, error={}", userId, e.getMessage());
+        }
+
+        try {
+            List<Map<String, Object>> ageRows = youtubeAnalyticsService.queryAllRows(userId,
+                    new YoutubeAnalyticsVideoRequest(startDate, endDate,
+                            List.of("viewerPercentage"), null, "ageGroup", null));
+            if (!ageRows.isEmpty()) {
+                Map<String, Double> ageMap = new HashMap<>();
+                for (Map<String, Object> row : ageRows) {
+                    ageMap.put((String) row.get("ageGroup"),
+                            ((Number) row.get("viewerPercentage")).doubleValue());
+                }
+                audienceAge = ageMap;
+            }
+        } catch (Exception e) {
+            log.warn("연령 분포 수집 실패 (시청자 데이터 부족 또는 API 오류): userId={}, error={}", userId, e.getMessage());
+        }
+
+        try {
+            List<Map<String, Object>> countryRows = youtubeAnalyticsService.queryAllRows(userId,
+                    new YoutubeAnalyticsVideoRequest(startDate, endDate,
+                            List.of("views"), null, "country", null));
+            if (!countryRows.isEmpty()) {
+                Map<String, Double> countryMap = new HashMap<>();
+                for (Map<String, Object> row : countryRows) {
+                    countryMap.put((String) row.get("country"),
+                            ((Number) row.get("views")).doubleValue());
+                }
+                audienceCountry = countryMap;
+            }
+        } catch (Exception e) {
+            log.warn("국가 분포 수집 실패 (시청자 데이터 부족 또는 API 오류): userId={}, error={}", userId, e.getMessage());
+        }
+
+        ChannelStats stats = channelStatsRepository.findByChannel_Id(channel.getId())
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
+        stats.updateAnalyticsStats(subscriberViewCount, avgEngagementRate, audienceGender, audienceAge, audienceCountry);
 
         User updatedUser = userReadRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));

--- a/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
@@ -38,6 +38,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Plan plan;
 
+    @Column(name = "onboarding_completed", nullable = false, columnDefinition = "boolean default false")
+    private boolean isOnboardingCompleted;
+
     @Builder
     public User(String name, String profileImage, String email,
                 String providerId, Plan plan) {
@@ -46,5 +49,9 @@ public class User {
         this.email = email;
         this.providerId = providerId;
         this.plan = plan;
+    }
+
+    public void completeOnboarding() {
+        this.isOnboardingCompleted = true;
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
@@ -24,13 +24,12 @@ public class UserCommandRepository {
         values (?, ?, ?, ?, ?)
         on conflict (provider_id)
         do update set provider_id = excluded.provider_id
-        returning user_id, (xmax = 0) as inserted
+        returning user_id
     """, sub, name, email, profileImage, plan.name());
 
         Long userId = ((Number) result.get("user_id")).longValue();
-        boolean isNew = (Boolean) result.get("inserted");
 
-        return new UserRegistrationResult(userId, isNew);
+        return new UserRegistrationResult(userId);
     }
 
     public void deleteUser(long userId) {
@@ -53,6 +52,13 @@ public class UserCommandRepository {
                     ps.setLong(1, userId);
                     ps.setString(2, need.name());
                 }
+        );
+    }
+
+    public void updateOnboardingCompleted(long userId) {
+        jdbcTemplate.update(
+                "update users set onboarding_completed = true where user_id = ?",
+                userId
         );
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/infra/UserRegistrationResult.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserRegistrationResult.java
@@ -1,4 +1,4 @@
 package com.example.inflace.domain.user.infra;
 
-public record UserRegistrationResult(long userId, boolean isNewUser) {
+public record UserRegistrationResult(long userId) {
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
@@ -35,6 +35,13 @@ public interface UserApi {
     BaseResponse<UserChannelMainResponse> getUserChannelMain(@AuthenticationPrincipal AuthUser authUser);
 
     @Operation(
+            summary = "유튜브 채널 연동",
+            description = "구글 OAuth 코드를 통해 유튜브 채널 정보를 가져와 유저에 저장합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.YOUTUBE_TOKEN_NOT_FOUND, ErrorDefine.YOUTUBE_CHANNEL_NOT_FOUND})
+    BaseResponse<YoutubeChannelLinkResponse> linkYoutubeChannel(@AuthenticationPrincipal AuthUser authUser);
+
+    @Operation(
             summary = "회원 탈퇴",
             description = "현재 로그인된 유저를 영구 삭제합니다 (복구 불가)"
     )

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -54,6 +54,16 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @PostMapping("/youtube/link")
+    public BaseResponse<YoutubeChannelLinkResponse> linkYoutubeChannel(
+            @AuthenticationPrincipal AuthUser authUser) {
+        if (authUser == null) {
+            throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
+        }
+        return new BaseResponse<>(userService.linkYoutubeChannel(authUser.userId()));
+    }
+
+    @Override
     @DeleteMapping("/delete")
     public ResponseEntity<BaseResponse<Void>> withdraw(
             @AuthenticationPrincipal AuthUser authUser) {

--- a/src/main/java/com/example/inflace/domain/user/presentation/YoutubeChannelLinkResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/YoutubeChannelLinkResponse.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.user.presentation;
+
+public record YoutubeChannelLinkResponse(
+        String channelName,
+        String channelProfileImage,
+        String accessToken
+) {}

--- a/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
+++ b/src/main/java/com/example/inflace/domain/video/dto/YoutubeAnalyticsVideoRequest.java
@@ -8,7 +8,8 @@ public record YoutubeAnalyticsVideoRequest(
         LocalDate endDate,
         List<String> metrics,
         String youtubeVideoId,
-        String dimensions
+        String dimensions,
+        String filters
 ) {
     public String formattedMetricsList() {
         return String.join(",", metrics);

--- a/src/main/java/com/example/inflace/domain/video/service/VideoSyncService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoSyncService.java
@@ -65,7 +65,8 @@ public class VideoSyncService {
                 LocalDate.now().minusDays(3),
                 STATS_METRICS,
                 video.getYoutubeVideoId(),
-                "video"
+                "video",
+                null
         );
 
         Map<String, Object> data = youtubeAnalyticsService.query(userId, request);
@@ -117,7 +118,8 @@ public class VideoSyncService {
                 LocalDate.now().minusDays(3),
                 RETENTION_METRICS,
                 video.getYoutubeVideoId(),
-                "elapsedVideoTimeRatio"
+                "elapsedVideoTimeRatio",
+                null
         );
 
         YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);
@@ -173,7 +175,8 @@ public class VideoSyncService {
                 LocalDate.now().minusDays(3),
                 UNSUBSCRIBED_METRICS,
                 video.getYoutubeVideoId(),
-                "subscribedStatus"
+                "subscribedStatus",
+                null
         );
 
         YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);

--- a/src/main/java/com/example/inflace/domain/video/service/VideoSyncService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoSyncService.java
@@ -1,7 +1,5 @@
 package com.example.inflace.domain.video.service;
 
-import com.example.inflace.domain.user.domain.entity.User;
-import com.example.inflace.domain.user.infra.UserReadRepository;
 import com.example.inflace.domain.video.domain.AudienceRetention;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.domain.VideoStats;
@@ -50,7 +48,6 @@ public class VideoSyncService {
     private final VideoRepository videoRepository;
     private final VideoStatsRepository videoStatsRepository;
     private final AudienceRetentionRepository audienceRetentionRepository;
-    private final UserReadRepository userReadRepository;
     private final YoutubeAnalyticsService youtubeAnalyticsService;
     private final YoutubeAnalyticsApiClient youtubeAnalyticsApiClient;
 
@@ -62,7 +59,6 @@ public class VideoSyncService {
     @Transactional
     public void syncStats(long userId, long videoId) {
         Video video = findVideoWithOwnership(userId, videoId);
-        String googleId = getGoogleId(userId);
 
         YoutubeAnalyticsVideoRequest request = new YoutubeAnalyticsVideoRequest(
                 video.getCreatedAt().toLocalDate(),
@@ -72,7 +68,7 @@ public class VideoSyncService {
                 "video"
         );
 
-        Map<String, Object> data = youtubeAnalyticsService.query(googleId, request);
+        Map<String, Object> data = youtubeAnalyticsService.query(userId, request);
 
         if (data.isEmpty()) {
             return;
@@ -115,7 +111,6 @@ public class VideoSyncService {
     @Transactional
     public void syncRetention(long userId, long videoId) {
         Video video = findVideoWithOwnership(userId, videoId);
-        String googleId = getGoogleId(userId);
 
         YoutubeAnalyticsVideoRequest request = new YoutubeAnalyticsVideoRequest(
                 video.getCreatedAt().toLocalDate(),
@@ -125,7 +120,7 @@ public class VideoSyncService {
                 "elapsedVideoTimeRatio"
         );
 
-        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(googleId, request);
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);
 
         if (response.rows() == null || response.rows().size() != 100) {
             throw new ApiException(ErrorDefine.RETENTION_INVALID);
@@ -167,7 +162,6 @@ public class VideoSyncService {
     @Transactional
     public void syncUnsubscribedStats(long userId, long videoId) {
         Video video = findVideoWithOwnership(userId, videoId);
-        String googleId = getGoogleId(userId);
 
         Optional<VideoStats> existing = videoStatsRepository.findByVideo(video);
         if (existing.isEmpty()) {
@@ -182,7 +176,7 @@ public class VideoSyncService {
                 "subscribedStatus"
         );
 
-        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(googleId, request);
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);
 
         log.info("columnHeaders: {}", response.columnHeaders());
         log.info("rows: {}", response.rows());
@@ -214,12 +208,6 @@ public class VideoSyncService {
             throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
         }
         return video;
-    }
-
-    private String getGoogleId(long userId) {
-        User user = userReadRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
-        return user.getProviderId();
     }
 
     private Map<String, Integer> buildIndexMap(List<YoutubeAnalyticsVideoResponse.ColumnHeader> headers) {

--- a/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
@@ -28,7 +28,7 @@ public class YoutubeAnalyticsApiClient {
     private final YoutubeProperties youtubeProperties;
     private final GoogleAccessTokenStore googleAccessTokenStore;
 
-    public YoutubeAnalyticsVideoResponse getYoutubeAnalytics(String googleId, YoutubeAnalyticsVideoRequest request) {
+    public YoutubeAnalyticsVideoResponse getYoutubeAnalytics(long userId, YoutubeAnalyticsVideoRequest request) {
         UriComponentsBuilder builder = UriComponentsBuilder
                 .fromUriString(youtubeProperties.analyticsApi().baseUrl())
                 .path(ANALYTICS_PATH)
@@ -56,7 +56,7 @@ public class YoutubeAnalyticsApiClient {
 
         return restClient.get()
                 .uri(uri)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessTokenStore.getAccessToken(googleId))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessTokenStore.getAccessToken(userId))
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
                     log.error("YouTube API 4xx error: {}", new String(res.getBody().readAllBytes()));

--- a/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeAnalyticsApiClient.java
@@ -41,15 +41,22 @@ public class YoutubeAnalyticsApiClient {
             builder.queryParam("dimensions", request.dimensions());
         }
 
-        if (request.youtubeVideoId() != null) {
-            String filterValue = "video==" + request.youtubeVideoId();
-
-            // 시청 유지율(elapsedVideoTimeRatio) 조회 시 필수 필터 추가
-            if ("elapsedVideoTimeRatio".equals(request.dimensions())) {
-                filterValue += ";audienceType==ORGANIC";
+        if (request.youtubeVideoId() != null || request.filters() != null) {
+            StringBuilder filterBuilder = new StringBuilder();
+            if (request.youtubeVideoId() != null) {
+                filterBuilder.append("video==").append(request.youtubeVideoId());
+                // 시청 유지율(elapsedVideoTimeRatio) 조회 시 필수 필터 추가
+                if ("elapsedVideoTimeRatio".equals(request.dimensions())) {
+                    filterBuilder.append(";audienceType==ORGANIC");
+                }
             }
-
-            builder.queryParam("filters", filterValue);
+            if (request.filters() != null) {
+                if (!filterBuilder.isEmpty()) {
+                    filterBuilder.append(";");
+                }
+                filterBuilder.append(request.filters());
+            }
+            builder.queryParam("filters", filterBuilder.toString());
         }
 
         URI uri = builder.build().toUri();

--- a/src/main/java/com/example/inflace/global/client/YoutubeDataApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeDataApiClient.java
@@ -56,7 +56,7 @@ public class YoutubeDataApiClient {
         URI uri = UriComponentsBuilder
                 .fromUriString(youtubeProperties.dataApi().baseUrl())
                 .path(CHANNELS_PATH)
-                .queryParam("part", "snippet")
+                .queryParam("part", "snippet,statistics,topicDetails")
                 .queryParam("mine", "true")
                 .build()
                 .toUri();

--- a/src/main/java/com/example/inflace/global/client/YoutubeDataApiClient.java
+++ b/src/main/java/com/example/inflace/global/client/YoutubeDataApiClient.java
@@ -5,6 +5,7 @@ import com.example.inflace.domain.video.dto.YoutubeDataVideoResponse;
 import com.example.inflace.global.properties.YoutubeProperties;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -49,5 +50,21 @@ public class YoutubeDataApiClient {
                 .uri(uri)
                 .retrieve()
                 .body(YoutubeDataVideoResponse.class);
+    }
+
+    public YoutubeDataChannelResponse getMyChannel(String accessToken) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(youtubeProperties.dataApi().baseUrl())
+                .path(CHANNELS_PATH)
+                .queryParam("part", "snippet")
+                .queryParam("mine", "true")
+                .build()
+                .toUri();
+
+        return restClient.get()
+                .uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(YoutubeDataChannelResponse.class);
     }
 }

--- a/src/main/java/com/example/inflace/global/config/JwtProvider.java
+++ b/src/main/java/com/example/inflace/global/config/JwtProvider.java
@@ -18,11 +18,13 @@ public class JwtProvider {
 
     private static final String CLAIM_PROFILE_IMAGE = "profileImage";
     private static final String CLAIM_PLAN = "plan";
-    private static final String CLAIM_IS_NEW_USER = "isNewUser";
+    private static final String CLAIM_YOUTUBE_CHANNEL_NAME = "youtubeChannelName";
+    private static final String CLAIM_YOUTUBE_CHANNEL_PROFILE_IMAGE = "youtubeChannelProfileImage";
+    private static final String CLAIM_IS_ONBOARDING_COMPLETED = "isOnboardingCompleted";
 
     private final JwtProperties jwtProperties;
 
-    public String createAccessToken(long userId, String profileImage, boolean isNewUser, Plan plan) {
+    public String createAccessToken(long userId, String profileImage, Plan plan, String youtubeChannelName, String youtubeChannelProfileImage, boolean isOnboardingCompleted) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(userId))
@@ -30,7 +32,9 @@ public class JwtProvider {
                 .expiration(new Date(now.getTime() + jwtProperties.expiration()))
                 .claim(CLAIM_PROFILE_IMAGE, profileImage)
                 .claim(CLAIM_PLAN, plan)
-                .claim(CLAIM_IS_NEW_USER, isNewUser)
+                .claim(CLAIM_YOUTUBE_CHANNEL_NAME, youtubeChannelName)
+                .claim(CLAIM_YOUTUBE_CHANNEL_PROFILE_IMAGE, youtubeChannelProfileImage)
+                .claim(CLAIM_IS_ONBOARDING_COMPLETED, isOnboardingCompleted)
                 .signWith(getSigningKey())
                 .compact();
     }
@@ -57,8 +61,16 @@ public class JwtProvider {
         return parseClaims(token).get(CLAIM_PLAN, String.class);
     }
 
-    public boolean getIsNewUser(String token) {
-        Boolean value = parseClaims(token).get(CLAIM_IS_NEW_USER, Boolean.class);
+    public String getYoutubeChannelName(String token) {
+        return parseClaims(token).get(CLAIM_YOUTUBE_CHANNEL_NAME, String.class);
+    }
+
+    public String getYoutubeChannelProfileImage(String token) {
+        return parseClaims(token).get(CLAIM_YOUTUBE_CHANNEL_PROFILE_IMAGE, String.class);
+    }
+
+    public boolean getIsOnboardingCompleted(String token) {
+        Boolean value = parseClaims(token).get(CLAIM_IS_ONBOARDING_COMPLETED, Boolean.class);
         return Boolean.TRUE.equals(value);
     }
 

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -29,6 +29,8 @@ public enum ErrorDefine {
     CHANNEL_STATS_NOT_FOUND("CHANNEL_STATS_404", HttpStatus.NOT_FOUND, " Not Found: Channel Stats not found"),
 
     //ETC
+    YOUTUBE_TOKEN_NOT_FOUND("YOUTUBE_401", HttpStatus.UNAUTHORIZED, "Unauthorized: YouTube access token not found. Please link your YouTube account first"),
+    YOUTUBE_CHANNEL_NOT_FOUND("YOUTUBE_404", HttpStatus.NOT_FOUND, "Not Found: YouTube channel not found"),
     YOUTUBE_API_ERROR("YOUTUBE_500", HttpStatus.INTERNAL_SERVER_ERROR, "YouTube API Error");
 
     private final String errorCode;

--- a/src/main/java/com/example/inflace/global/service/YoutubeAnalyticsService.java
+++ b/src/main/java/com/example/inflace/global/service/YoutubeAnalyticsService.java
@@ -54,4 +54,27 @@ public class YoutubeAnalyticsService {
                         e -> row.get(e.getValue())
                 ));
     }
+
+    public List<Map<String, Object>> queryAllRows(long userId, YoutubeAnalyticsVideoRequest request) {
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);
+
+        if (response.rows() == null || response.rows().isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, Integer> columnIndex = IntStream.range(0, response.columnHeaders().size())
+                .boxed()
+                .collect(Collectors.toMap(
+                        i -> response.columnHeaders().get(i).name(),
+                        i -> i
+                ));
+
+        return response.rows().stream()
+                .map(row -> columnIndex.entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> row.get(e.getValue())
+                        )))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/inflace/global/service/YoutubeAnalyticsService.java
+++ b/src/main/java/com/example/inflace/global/service/YoutubeAnalyticsService.java
@@ -22,9 +22,9 @@ public class YoutubeAnalyticsService {
 
     private final YoutubeAnalyticsApiClient youtubeAnalyticsApiClient;
 
-    public Map<String, Object> query(String googleId, YoutubeAnalyticsVideoRequest request) {
+    public Map<String, Object> query(long userId, YoutubeAnalyticsVideoRequest request) {
 
-        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(googleId, request);
+        YoutubeAnalyticsVideoResponse response = youtubeAnalyticsApiClient.getYoutubeAnalytics(userId, request);
 
         if (response.rows() == null || response.rows().isEmpty()) {
             return Map.of();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
 springdoc:
   api-docs:


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

#63 

---

## comment
<!-- 남길 코멘트 -->

구글 계정이 유튜브 연동안하면 페이로드에 채널명, 유튜브 프사가 없고,
연동을 했을 경우에만 페이로드에 생깁니다~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * YouTube 채널 연동 기능 추가 - 사용자가 YouTube 채널을 계정에 연결할 수 있습니다.
  * 채널 프로필 이미지 지원 추가
  * 사용자 온보딩 완료 상태 추적 기능 추가

* **기능 개선**
  * 사용자 인증 토큰에 YouTube 채널 정보 및 온보딩 완료 상태 포함
  * YouTube 분석 데이터 조회 및 처리 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->