### PR TITLE
영상 시간, 롱숏폼 타입 추가

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelVideoRow.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelVideoRow.java
@@ -8,12 +8,15 @@ public record ChannelVideoRow(
         String title,
         String thumbnailUrl,
         LocalDateTime publishedAt,
+        Double duration,
+        Boolean isShort,
         Long viewCount,
         Long likeCount,
         Long commentCount,
         Double ctr,
         Double vph,
         Double outlierScore
+
 ) {
     public ChannelVideosResponse.ChannelVideoItem toItem() {
         return new ChannelVideosResponse.ChannelVideoItem(
@@ -23,7 +26,9 @@ public record ChannelVideoRow(
                 publishedAt,
                 viewCount,
                 likeCount,
-                commentCount
+                commentCount,
+                duration,
+                isShort
         );
     }
 

--- a/src/main/java/com/example/inflace/domain/channel/dto/ChannelVideosResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/ChannelVideosResponse.java
@@ -14,7 +14,9 @@ public record ChannelVideosResponse(
             LocalDateTime publishedAt,
             Long viewCount,
             Long likeCount,
-            Long commentCount
+            Long commentCount,
+            Double duration,
+            Boolean isShort
     ) {
     }
 

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
@@ -58,6 +58,8 @@ public class VideoQueryRepositoryImpl implements VideoQueryRepository {
                         video.title,
                         video.thumbnailUrl,
                         video.publishedAt,
+                        video.duration,
+                        video.isShort,
                         stats.viewCount.coalesce(0L),
                         stats.likeCount.coalesce(0L),
                         stats.commentCount.coalesce(0L),


### PR DESCRIPTION
##  Issue
closed #65 

---

## comment
프론트엔드의 요구사항에 따라 내영상목록 조회에서 영상 시간과 롱숏폼타입을 추가로 반환하게 하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채널 비디오 응답에 비디오 길이 정보가 추가되었습니다.
  * 비디오가 숏폼 콘텐츠인지 여부를 나타내는 속성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->