### PR TITLE
In 248 비디오목록 날짜필터 추가

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -92,7 +92,7 @@ public interface ChannelApi {
             summary = "영상 목록 조회",
             description = "내 채널의 영상목록을 조회합니다. 기간 필터는 yyyy-MM-dd 형식의 startDate/endDate로 전달합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.INVALID_DATE_FORMAT, ErrorDefine.INVALID_DATE_RANGE})
     BaseResponse<CursorSliceResponse<ChannelVideosResponse.ChannelVideoItem>> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -89,12 +89,14 @@ public interface ChannelApi {
 
     @Operation(
             summary = "영상 목록 조회",
-            description = "내 채널의 영상목록을 조회합니다."
+            description = "내 채널의 영상목록을 조회합니다. 기간 필터는 yyyy-MM-dd 형식의 startDate/endDate로 전달합니다."
     )
     @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
     BaseResponse<ChannelVideosResponse> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
             @RequestParam(required = false, defaultValue = "LATEST") String sort,
             @RequestParam(required = false, defaultValue = "ALL") String format,
             @RequestParam(required = false) Boolean isAd,

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -13,6 +13,7 @@ import com.example.inflace.domain.channel.dto.response.ChannelVideosResponse;
 import com.example.inflace.global.exception.ApiErrorDefines;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.response.BaseResponse;
+import com.example.inflace.global.response.CursorSliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -92,7 +93,7 @@ public interface ChannelApi {
             description = "내 채널의 영상목록을 조회합니다. 기간 필터는 yyyy-MM-dd 형식의 startDate/endDate로 전달합니다."
     )
     @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
-    BaseResponse<ChannelVideosResponse> getChannelVideos(
+    BaseResponse<CursorSliceResponse<ChannelVideosResponse.ChannelVideoItem>> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String startDate,

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -13,6 +13,7 @@ import com.example.inflace.domain.channel.dto.response.ChannelSyncResponse;
 import com.example.inflace.domain.channel.service.ChannelService;
 import com.example.inflace.domain.channel.service.YoutubeChannelSyncService;
 import com.example.inflace.global.response.BaseResponse;
+import com.example.inflace.global.response.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -90,7 +91,7 @@ public class ChannelController implements ChannelApi {
     }
 
     @GetMapping("/{channelId}/videos")
-    public BaseResponse<ChannelVideosResponse> getChannelVideos(
+    public BaseResponse<CursorSliceResponse<ChannelVideosResponse.ChannelVideoItem>> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String startDate,

--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelController.java
@@ -93,13 +93,25 @@ public class ChannelController implements ChannelApi {
     public BaseResponse<ChannelVideosResponse> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
             @RequestParam(defaultValue = "LATEST") String sort,
             @RequestParam(defaultValue = "ALL") String format,
             @RequestParam(required = false) Boolean isAd,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "12") Integer size
     ) {
-        return new BaseResponse<>(channelService.getChannelVideos(channelId, keyword, sort, format, isAd, cursor, size));
+        return new BaseResponse<>(channelService.getChannelVideos(
+                channelId,
+                keyword,
+                startDate,
+                endDate,
+                sort,
+                format,
+                isAd,
+                cursor,
+                size
+        ));
     }
 
     @GetMapping("/{channelId}/subscriber-trend")

--- a/src/main/java/com/example/inflace/domain/channel/dto/request/ChannelVideosRequest.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/request/ChannelVideosRequest.java
@@ -1,7 +1,13 @@
 package com.example.inflace.domain.channel.dto.request;
 
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
+import java.time.LocalDate;
+
 public record ChannelVideosRequest(
         String keyword,
+        LocalDate startDate,
+        LocalDate endDate,
         ChannelVideoSort sort,
         ChannelVideoFormat format,
         Boolean isAd,
@@ -15,6 +21,7 @@ public record ChannelVideosRequest(
         sort = sort == null ? ChannelVideoSort.LATEST : sort;
         format = format == null ? ChannelVideoFormat.ALL : format;
         size = normalizeSize(size);
+        validateDateRange(startDate, endDate);
     }
 
     private static int normalizeSize(Integer size) {
@@ -22,5 +29,11 @@ public record ChannelVideosRequest(
             return DEFAULT_SIZE;
         }
         return Math.min(size, MAX_SIZE);
+    }
+
+    private static void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new ApiException(ErrorDefine.INVALID_DATE_RANGE);
+        }
     }
 }

--- a/src/main/java/com/example/inflace/domain/channel/dto/response/ChannelSubscriberDistributionResponse.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/response/ChannelSubscriberDistributionResponse.java
@@ -92,6 +92,10 @@ public record ChannelSubscriberDistributionResponse(
             }
         }
 
+        if (type == DistributionType.AGE && code != null && code.endsWith("-")) {
+            return code.substring(0, code.length() - 1);
+        }
+
         return code;
     }
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -36,6 +36,8 @@ import com.example.inflace.global.annotation.ReadOnlyTransactional;
 import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.CursorSliceResponse;
+import com.example.inflace.global.response.CustomSort;
 import com.example.inflace.global.security.util.SecurityUtils;
 import com.example.inflace.global.util.AnalyticsCalculator;
 import java.time.LocalDate;
@@ -218,7 +220,7 @@ public class ChannelService {
 
 
     @ReadOnlyTransactional
-    public ChannelVideosResponse getChannelVideos(
+    public CursorSliceResponse<ChannelVideosResponse.ChannelVideoItem> getChannelVideos(
             Long channelId,
             String keyword,
             String startDate,
@@ -260,13 +262,15 @@ public class ChannelService {
         );
         ChannelVideoSliceResult result = videoQueryRepository.findChannelVideos(channelId, request);
 
-        return new ChannelVideosResponse(
+        return new CursorSliceResponse<>(
                 result.videos(),
-                new ChannelVideosResponse.PageInfo(
+                new CursorSliceResponse.PageInfo(
                         request.size(),
+                        result.videos().size(),
                         result.nextCursor(),
                         result.hasNext()
-                )
+                ),
+                CustomSort.of(true, request.sort().name(), "DESC")
         );
     }
 

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -41,6 +41,7 @@ import com.example.inflace.global.util.AnalyticsCalculator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import org.springframework.data.domain.Limit;
 import java.util.ArrayList;
@@ -220,6 +221,8 @@ public class ChannelService {
     public ChannelVideosResponse getChannelVideos(
             Long channelId,
             String keyword,
+            String startDate,
+            String endDate,
             String sort,
             String format,
             Boolean isAd,
@@ -242,7 +245,19 @@ public class ChannelService {
             throw new ApiException(ErrorDefine.INVALID_ARGUMENT);
         }
 
-        ChannelVideosRequest request = new ChannelVideosRequest(keyword, parsedSort, parsedFormat, isAd, cursor, size);
+        LocalDate parsedStartDate = parseDate(startDate);
+        LocalDate parsedEndDate = parseDate(endDate);
+
+        ChannelVideosRequest request = new ChannelVideosRequest(
+                keyword,
+                parsedStartDate,
+                parsedEndDate,
+                parsedSort,
+                parsedFormat,
+                isAd,
+                cursor,
+                size
+        );
         ChannelVideoSliceResult result = videoQueryRepository.findChannelVideos(channelId, request);
 
         return new ChannelVideosResponse(
@@ -253,6 +268,18 @@ public class ChannelService {
                         result.hasNext()
                 )
         );
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new ApiException(ErrorDefine.INVALID_DATE_FORMAT);
+        }
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -46,6 +47,11 @@ public class VideoQueryRepositoryImpl implements VideoQueryRepository {
 
         if (request.isAd() != null) {
             predicate.and(video.isAdvertisement.eq(request.isAd()));
+        }
+
+        BooleanExpression publishedAtCondition = buildPublishedAtCondition(request, video);
+        if (publishedAtCondition != null) {
+            predicate.and(publishedAtCondition);
         }
 
         BooleanExpression cursorCondition = buildCursorCondition(request, video, stats);
@@ -91,6 +97,22 @@ public class VideoQueryRepositoryImpl implements VideoQueryRepository {
         }
 
         return new ChannelVideoSliceResult(items, nextCursor, hasNext);
+    }
+
+    private BooleanExpression buildPublishedAtCondition(ChannelVideosRequest request, QVideo video) {
+        BooleanExpression condition = null;
+
+        if (request.startDate() != null) {
+            condition = video.publishedAt.goe(request.startDate().atStartOfDay());
+        }
+
+        if (request.endDate() != null) {
+            LocalDate exclusiveEndDate = request.endDate().plusDays(1);
+            BooleanExpression endCondition = video.publishedAt.lt(exclusiveEndDate.atStartOfDay());
+            condition = condition == null ? endCondition : condition.and(endCondition);
+        }
+
+        return condition;
     }
 
     private OrderSpecifier<?>[] buildOrderSpecifiers(ChannelVideoSort sort, QVideo video, QVideoStats stats) {

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -8,6 +8,8 @@ public enum ErrorDefine {
 
     INVALID_HEADER_ERROR("AUTH_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Header Error"),
     INVALID_ARGUMENT("COMMON_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Arguments"),
+    INVALID_DATE_FORMAT("COMMON_400_DATE_FORMAT", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date format"),
+    INVALID_DATE_RANGE("COMMON_400_DATE_RANGE", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date range"),
     AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider"),
     AUTHENTICATION_FAILED("AUTH_401_UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "Unauthorized: Authentication required"),
     INVALID_ACCESS_TOKEN("AUTH_401_ACCESS", HttpStatus.UNAUTHORIZED, "Unauthorized: Invalid access token"),


### PR DESCRIPTION
##  Issue
#103 

---

## comment
프론트엔드분들의 요청에 따라
- 비디오 목록에 날짜필터를 추가하였습니다.
- 구독자 분포 65세 이상의 응답필드에서 "-"를 제거하였습니다.
- 동영상 목록의 커서 응답을 공통양식으로 통일하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 채널 영상 조회 시 시작 날짜와 종료 날짜를 사용한 필터링 기능 추가
  * 커서 기반 페이지네이션으로 개선된 데이터 조회 방식 적용

* **개선 사항**
  * 날짜 형식 및 범위 검증 강화로 사용자 입력 오류 감지 개선
  * 연령대 카테고리 라벨 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->