### PR TITLE
feat: Idempotency-Key 기반 중복 요청 방지 필터를 추가 -> Dev

### DIFF
--- a/src/main/java/com/example/inflace/domain/idempotency/model/IdempotencyKeyMetadata.java
+++ b/src/main/java/com/example/inflace/domain/idempotency/model/IdempotencyKeyMetadata.java
@@ -1,0 +1,10 @@
+package com.example.inflace.domain.idempotency.model;
+
+import java.time.LocalDateTime;
+
+public record IdempotencyKeyMetadata(
+        String method,
+        String path,
+        LocalDateTime requestedAt
+) {
+}

--- a/src/main/java/com/example/inflace/domain/idempotency/service/IdempotencyService.java
+++ b/src/main/java/com/example/inflace/domain/idempotency/service/IdempotencyService.java
@@ -1,0 +1,17 @@
+package com.example.inflace.domain.idempotency.service;
+
+import com.example.inflace.domain.idempotency.model.IdempotencyKeyMetadata;
+import com.example.inflace.infra.redis.idempotency.IdempotencyRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final IdempotencyRedisRepository idempotencyRedisRepository;
+
+    public boolean saveIfAbsent(String idempotencyKey, IdempotencyKeyMetadata metadata) {
+        return idempotencyRedisRepository.saveIfAbsent(idempotencyKey, metadata);
+    }
+}

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -10,6 +10,7 @@ public enum ErrorDefine {
     INVALID_ARGUMENT("COMMON_400", HttpStatus.BAD_REQUEST, "Bad Request: Invalid Arguments"),
     INVALID_DATE_FORMAT("COMMON_400_DATE_FORMAT", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date format"),
     INVALID_DATE_RANGE("COMMON_400_DATE_RANGE", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date range"),
+    DUPLICATE_IDEMPOTENCY_REQUEST("COMMON_409_IDEMPOTENCY", HttpStatus.CONFLICT, "Conflict: Duplicate idempotency request"),
     AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider"),
     AUTHENTICATION_FAILED("AUTH_401_UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "Unauthorized: Authentication required"),
     INVALID_ACCESS_TOKEN("AUTH_401_ACCESS", HttpStatus.UNAUTHORIZED, "Unauthorized: Invalid access token"),

--- a/src/main/java/com/example/inflace/global/filter/IdempotencyKeyFilter.java
+++ b/src/main/java/com/example/inflace/global/filter/IdempotencyKeyFilter.java
@@ -1,0 +1,111 @@
+package com.example.inflace.global.filter;
+
+import com.example.inflace.domain.idempotency.model.IdempotencyKeyMetadata;
+import com.example.inflace.domain.idempotency.service.IdempotencyService;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.response.ApiFilterErrorResponseWriter;
+import com.example.inflace.global.security.config.SecurityAllowedPaths;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@Slf4j
+@RequiredArgsConstructor
+public class IdempotencyKeyFilter extends OncePerRequestFilter {
+
+    private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    private final IdempotencyService idempotencyService;
+    private final ApiFilterErrorResponseWriter apiFilterErrorResponseWriter;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+
+        if (!shouldFilterByMethodOrPath(request)) {
+            return true;
+        }
+
+        String idempotencyKey = resolveIdempotencyKey(request);
+        if (!StringUtils.hasText(idempotencyKey)) {
+            return true;
+        }
+
+        String requestPath = request.getServletPath();
+        return Arrays.stream(SecurityAllowedPaths.allowedPaths())
+                .anyMatch(path -> PATH_MATCHER.match(path, requestPath));
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String idempotencyKey = resolveIdempotencyKey(request);
+        IdempotencyKeyMetadata metadata = new IdempotencyKeyMetadata(
+                request.getMethod(),
+                request.getRequestURI(),
+                LocalDateTime.now()
+        );
+
+        boolean saved = idempotencyService.saveIfAbsent(idempotencyKey, metadata);
+        if (!saved) {
+            log.warn(
+                    "Duplicate idempotency request blocked. key={}, method={}, path={}",
+                    idempotencyKey,
+                    metadata.method(),
+                    metadata.path()
+            );
+            apiFilterErrorResponseWriter.write(
+                    request,
+                    response,
+                    ErrorDefine.DUPLICATE_IDEMPOTENCY_REQUEST,
+                    ErrorDefine.DUPLICATE_IDEMPOTENCY_REQUEST.getMessage()
+            );
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveIdempotencyKey(HttpServletRequest request) {
+        return request.getHeader(IDEMPOTENCY_KEY_HEADER);
+    }
+
+    private boolean shouldFilterByMethodOrPath(HttpServletRequest request) {
+        return isMutationMethod(request.getMethod())
+                || isInsightSummaryRequest(request);
+    }
+
+    private boolean isMutationMethod(String method) {
+        return HttpMethod.POST.matches(method)
+                || HttpMethod.PUT.matches(method)
+                || HttpMethod.PATCH.matches(method)
+                || HttpMethod.DELETE.matches(method);
+    }
+
+    private boolean isInsightSummaryRequest(HttpServletRequest request) {
+        if (!HttpMethod.GET.matches(request.getMethod())) {
+            return false;
+        }
+
+        String requestPath = request.getServletPath();
+        return Arrays.stream(IdempotencyTargetPaths.targetGetPaths())
+                .anyMatch(path -> PATH_MATCHER.match(path, requestPath));
+    }
+}

--- a/src/main/java/com/example/inflace/global/filter/IdempotencyTargetPaths.java
+++ b/src/main/java/com/example/inflace/global/filter/IdempotencyTargetPaths.java
@@ -1,0 +1,15 @@
+package com.example.inflace.global.filter;
+
+public final class IdempotencyTargetPaths {
+
+    private static final String[] TARGET_GET_PATHS = {
+            "/api/v1/influencers/*/insight-summary"
+    };
+
+    private IdempotencyTargetPaths() {
+    }
+
+    public static String[] targetGetPaths() {
+        return TARGET_GET_PATHS.clone();
+    }
+}

--- a/src/main/java/com/example/inflace/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/inflace/global/security/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.example.inflace.global.security.config;
 
+import com.example.inflace.domain.idempotency.service.IdempotencyService;
+import com.example.inflace.global.filter.IdempotencyKeyFilter;
+import com.example.inflace.global.response.ApiFilterErrorResponseWriter;
 import com.example.inflace.global.properties.CorsAllowedOriginsProperties;
 import com.example.inflace.global.security.custom.CustomAccessDeniedHandler;
 import com.example.inflace.global.security.custom.CustomAuthenticationEntryPoint;
@@ -31,6 +34,8 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CorsAllowedOriginsProperties corsAllowedOriginsProperties;
+    private final IdempotencyService idempotencyService;
+    private final ApiFilterErrorResponseWriter apiFilterErrorResponseWriter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -51,6 +56,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(
+                        new IdempotencyKeyFilter(idempotencyService, apiFilterErrorResponseWriter),
+                        JwtAuthenticationFilter.class
+                )
                 .build();
     }
 }

--- a/src/main/java/com/example/inflace/infra/redis/idempotency/IdempotencyRedisRepository.java
+++ b/src/main/java/com/example/inflace/infra/redis/idempotency/IdempotencyRedisRepository.java
@@ -1,0 +1,41 @@
+package com.example.inflace.infra.redis.idempotency;
+
+import com.example.inflace.domain.idempotency.model.IdempotencyKeyMetadata;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class IdempotencyRedisRepository {
+
+    private static final String IDEMPOTENCY_KEY_PREFIX = "idempotency:";
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(1);
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public boolean saveIfAbsent(String idempotencyKey, IdempotencyKeyMetadata metadata) {
+        try {
+            Boolean saved = redisTemplate.opsForValue().setIfAbsent(
+                    redisKey(idempotencyKey),
+                    objectMapper.writeValueAsString(metadata),
+                    IDEMPOTENCY_TTL
+            );
+            return Boolean.TRUE.equals(saved);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize idempotency metadata. key={}", idempotencyKey, e);
+            throw new IllegalStateException("Failed to serialize idempotency metadata", e);
+        }
+    }
+
+    private String redisKey(String idempotencyKey) {
+        return IDEMPOTENCY_KEY_PREFIX + idempotencyKey;
+    }
+}


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

---

## comment
<!-- 남길 코멘트 -->
- Idempotency Filter를 설정했습니다.
- 설정 의도는
  - 사용자 같은 요청 재전송
  - 네트워크 재시도, 더블클릭, 프론트 중복 호출 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* 중복 요청 방지 기능이 추가되었습니다. 동일한 API 요청이 재전송될 경우 시스템이 자동으로 감지하여 중복 요청 오류(409)를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->