### PR TITLE
feat: channel_brand 테이블에 원천 유튜브 영상 ID 정보 추가 -> Dev

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelBrand.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelBrand.java
@@ -42,6 +42,9 @@ public class ChannelBrand extends BaseTimeEntity {
     @Column(name = "matched_alias", nullable = false)
     private String matchedAlias;
 
+    @Column(name = "source_youtube_video_id", nullable = true)
+    private String sourceYoutubeVideoId;
+
     public static ChannelBrand of(Channel channel, Brand brand, String matchedAlias) {
         ChannelBrand relation = new ChannelBrand();
         relation.channel = channel;

--- a/src/main/resources/db/migration/V20260515135834__alter_table_channel_brand_add_column_source_youtube_video_id.sql
+++ b/src/main/resources/db/migration/V20260515135834__alter_table_channel_brand_add_column_source_youtube_video_id.sql
@@ -1,0 +1,2 @@
+alter table channel_brand
+add column source_youtube_video_id varchar(255);


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

---

## comment
<!-- 남길 코멘트 -->
- channel_brand 테이블에 원천 유튜브 영상 ID 정보 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채널 브랜드와 연결된 YouTube 비디오 정보를 추적할 수 있는 기능이 추가되었습니다. 이를 통해 채널 브랜드별 비디오 소스 관리가 보다 용이해졌습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/inflace-4th-server/pull/131)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->