### PR TITLE
In 298 채널 연동 예외처리 -> dev

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/ChannelApi.java
@@ -47,7 +47,7 @@ public interface ChannelApi {
             summary = "인기 급상승 영상 Top 5",
             description = "영상 타입별로 채널의 인기 급상승 Top 5 영상을 조회합니다. "
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<ChannelTopVideosResponse> getTopVideos(
             @PathVariable Long channelId,
             @RequestParam String contentType
@@ -57,42 +57,42 @@ public interface ChannelApi {
             summary = "참여율 차트",
             description = "채널의 롱폼/쇼츠 평균 참여율과 영상별 참여율 Top 5 리스트를 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<ChannelEngagementRateResponse> getEngagementRateVideos(@PathVariable Long channelId);
 
     @Operation(
             summary = "신규 유입 비율 TOP 영상",
             description = "채널의 신규 유입 비율이 높은 상위 5개 영상을 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.ANALYTICS_DATA_NOT_FOUND})
     BaseResponse<ChannelNewSubscriberResponse> getNewSubscriberVideos(@PathVariable Long channelId);
 
     @Operation(
             summary = "핵심 지표 카드(KPI)",
             description = "채널의 핵심 지표 카드를 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
     BaseResponse<ChannelKpiResponse> getChannelKpi(@PathVariable Long channelId);
 
     @Operation(
             summary = "구독자/비구독자 비율",
             description = "채널의 구독자 조회수와 비구독자 조회수 비율을 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.CHANNEL_STATS_NOT_FOUND, ErrorDefine.CHANNEL_ANALYTICS_NOT_FOUND, ErrorDefine.ANALYTICS_DATA_NOT_FOUND})
     BaseResponse<ChannelSubscriberPatternResponse> getSubscriberPattern(@PathVariable Long channelId);
 
     @Operation(
             summary = "구독자 분포",
             description = "채널의 국가별, 연령별, 성별 분포를 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.CHANNEL_STATS_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.CHANNEL_ANALYTICS_NOT_FOUND})
     BaseResponse<ChannelSubscriberDistributionResponse> getSubscriberDistribution(@PathVariable Long channelId);
 
     @Operation(
             summary = "영상 목록 조회",
             description = "내 채널의 영상목록을 조회합니다. 기간 필터는 yyyy-MM-dd 형식의 startDate/endDate로 전달합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.INVALID_DATE_FORMAT, ErrorDefine.INVALID_DATE_RANGE})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.INVALID_DATE_FORMAT, ErrorDefine.INVALID_DATE_RANGE})
     BaseResponse<CursorSliceResponse<ChannelVideosResponse.ChannelVideoItem>> getChannelVideos(
             @PathVariable Long channelId,
             @RequestParam(required = false) String keyword,
@@ -109,7 +109,7 @@ public interface ChannelApi {
             summary = "구독자 추이",
             description = "범위별 구독자 추이 6개 포인트를 조회합니다."
     )
-    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND})
+    @ApiErrorDefines({ErrorDefine.INVALID_ARGUMENT, ErrorDefine.CHANNEL_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<ChannelSubscriberTrendResponse> getSubscriberTrend(
             @PathVariable Long channelId,
             @RequestParam(defaultValue = "30D") String range

--- a/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
+++ b/src/main/java/com/example/inflace/domain/channel/domain/ChannelStats.java
@@ -59,22 +59,22 @@ public class ChannelStats extends BaseTimeEntity {
                         Double avgEngagementRateRecent, Double avgOutlierScoreRecentExcludingTop5Pct,
                         LocalDateTime collectedAt) {
         this.channel = channel;
-        this.subscriberCount = subscriberCount;
-        this.totalViewCount = totalViewCount;
-        this.totalVideoCount = totalVideoCount;
-        this.recentUploadCount30d = recentUploadCount30d;
-        this.avgViewsRecent = avgViewsRecent;
-        this.avgEngagementRateRecent = avgEngagementRateRecent;
-        this.avgOutlierScoreRecentExcludingTop5Pct = avgOutlierScoreRecentExcludingTop5Pct;
-        this.collectedAt = collectedAt;
+        this.subscriberCount = subscriberCount == null ? 0L : subscriberCount;
+        this.totalViewCount = totalViewCount == null ? 0L : totalViewCount;
+        this.totalVideoCount = totalVideoCount == null ? 0L : totalVideoCount;
+        this.recentUploadCount30d = recentUploadCount30d == null ? 0 : recentUploadCount30d;
+        this.avgViewsRecent = avgViewsRecent == null ? 0.0 : avgViewsRecent;
+        this.avgEngagementRateRecent = avgEngagementRateRecent == null ? 0.0 : avgEngagementRateRecent;
+        this.avgOutlierScoreRecentExcludingTop5Pct = avgOutlierScoreRecentExcludingTop5Pct == null ? 0.0 : avgOutlierScoreRecentExcludingTop5Pct;
+        this.collectedAt = collectedAt == null ? LocalDateTime.now() : collectedAt;
     }
 
     public void update(Long subscriberCount, Long totalViewCount, Long totalVideoCount,
                        LocalDateTime collectedAt) {
-        this.subscriberCount = subscriberCount;
-        this.totalViewCount = totalViewCount;
-        this.totalVideoCount = totalVideoCount;
-        this.collectedAt = collectedAt;
+        this.subscriberCount = subscriberCount == null ? 0L : subscriberCount;
+        this.totalViewCount = totalViewCount == null ? 0L : totalViewCount;
+        this.totalVideoCount = totalVideoCount == null ? 0L : totalVideoCount;
+        this.collectedAt = collectedAt == null ? LocalDateTime.now() : collectedAt;
     }
 
     public void updateCalculatedMetrics(
@@ -84,11 +84,11 @@ public class ChannelStats extends BaseTimeEntity {
             Double avgOutlierScoreRecentExcludingTop5Pct,
             LocalDateTime collectedAt
     ) {
-        this.recentUploadCount30d = recentUploadCount30d;
-        this.avgViewsRecent = avgViewsRecent;
-        this.avgEngagementRateRecent = avgEngagementRateRecent;
-        this.avgOutlierScoreRecentExcludingTop5Pct = avgOutlierScoreRecentExcludingTop5Pct;
-        this.collectedAt = collectedAt;
+        this.recentUploadCount30d = recentUploadCount30d == null ? 0 : recentUploadCount30d;
+        this.avgViewsRecent = avgViewsRecent == null ? 0.0 : avgViewsRecent;
+        this.avgEngagementRateRecent = avgEngagementRateRecent == null ? 0.0 : avgEngagementRateRecent;
+        this.avgOutlierScoreRecentExcludingTop5Pct = avgOutlierScoreRecentExcludingTop5Pct == null ? 0.0 : avgOutlierScoreRecentExcludingTop5Pct;
+        this.collectedAt = collectedAt == null ? LocalDateTime.now() : collectedAt;
     }
 
     public Double getAvgEngagementRate() {

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -77,7 +77,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelTopVideosResponse getTopVideos(Long channelId, String contentType) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         VideoType parsedContentType;
         try {
@@ -100,7 +103,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelEngagementRateResponse getEngagementRateVideos(Long channelId) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         List<Video> allVideos = videoRepository.findByChannelId(channelId);
         Map<Long, VideoStats> allVideoStatsMap = getVideoStatsMap(allVideos);
@@ -115,7 +121,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelNewSubscriberResponse getNewSubscriberVideos(Long channelId) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         List<Video> videos = videoRepository.findTopNewSubscriberVideos(
                 channelId,
@@ -140,7 +149,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelKpiResponse getChannelKpi(Long channelId) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
@@ -205,7 +217,10 @@ public class ChannelService {
     }
 
     public ChannelSubscriberPatternResponse getSubscriberPattern(Long channelId) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         ChannelStats channelStats = channelStatsRepository.findByChannel_Id(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
@@ -227,7 +242,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelSubscriberDistributionResponse getSubscriberDistribution(Long channelId) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         ChannelAnalytics channelAnalytics = channelAnalyticsRepository.findByChannel_Id(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_ANALYTICS_NOT_FOUND));
@@ -252,7 +270,10 @@ public class ChannelService {
             String cursor,
             Integer size
     ) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         ChannelVideoSort parsedSort;
         try {
@@ -309,7 +330,10 @@ public class ChannelService {
 
     @ReadOnlyTransactional
     public ChannelSubscriberTrendResponse getSubscriberTrend(Long channelId, String rangeValue) {
-        validateChannelExists(channelId);
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_NOT_FOUND));
+        validateChannelOwnership(channel, userId);
 
         ChannelSubscriberTrendRange range = ChannelSubscriberTrendRange.from(rangeValue);
         SubscriberLog latestHistory = subscriberLogRepository

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -130,6 +130,7 @@ public class ChannelService {
         for (Video video : videos) {
             VideoStats videoStats = videoStatsMap.get(video.getId());
             VideoAnalytics videoAnalytics = videoAnalyticsMap.get(video.getId());
+            validateNewSubscriberAnalytics(videoStats, videoAnalytics);
             items.add(ChannelNewSubscriberResponse.NewSubscriberVideo.from(rank, video, videoStats, videoAnalytics));
             rank++;
         }
@@ -192,6 +193,17 @@ public class ChannelService {
         }
     }
 
+    private void validateNewSubscriberAnalytics(VideoStats videoStats, VideoAnalytics videoAnalytics) {
+        if (videoStats == null
+                || videoStats.getViewCount() == null
+                || videoAnalytics == null
+                || videoAnalytics.getSubscribersGained() == null
+                || videoAnalytics.getUnsubscribedViewerPercentage() == null
+                || videoAnalytics.getAverageViewPercentage() == null) {
+            throw new ApiException(ErrorDefine.ANALYTICS_DATA_NOT_FOUND);
+        }
+    }
+
     public ChannelSubscriberPatternResponse getSubscriberPattern(Long channelId) {
         validateChannelExists(channelId);
 
@@ -199,11 +211,18 @@ public class ChannelService {
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_STATS_NOT_FOUND));
         ChannelAnalytics channelAnalytics = channelAnalyticsRepository.findByChannel_Id(channelId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.CHANNEL_ANALYTICS_NOT_FOUND));
+        validateSubscriberPatternAnalytics(channelStats, channelAnalytics);
 
         return ChannelSubscriberPatternResponse.from(
                 channelStats.getTotalViewCount(),
                 channelAnalytics.getSubscriberViewCount()
         );
+    }
+
+    private void validateSubscriberPatternAnalytics(ChannelStats channelStats, ChannelAnalytics channelAnalytics) {
+        if (channelStats.getTotalViewCount() == null || channelAnalytics.getSubscriberViewCount() == null) {
+            throw new ApiException(ErrorDefine.ANALYTICS_DATA_NOT_FOUND);
+        }
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/com/example/inflace/domain/channel/service/YoutubeChannelDataSyncService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/YoutubeChannelDataSyncService.java
@@ -69,6 +69,7 @@ public class YoutubeChannelDataSyncService {
         upsertChannelStats(channel, channelItem.statistics());
         syncChannelVideos(googleId, channel, channelItem.statistics());
         refreshCalculatedChannelStats(channel);
+        refreshVideoRisingScores(channel);
         refreshChannelCategories(channel);
 
         return new ChannelDataSyncResult(channel, videoRepository.findByChannelId(channel.getId()));

--- a/src/main/java/com/example/inflace/domain/channel/service/YoutubeChannelDataSyncService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/YoutubeChannelDataSyncService.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -68,7 +69,6 @@ public class YoutubeChannelDataSyncService {
         upsertChannelStats(channel, channelItem.statistics());
         syncChannelVideos(googleId, channel, channelItem.statistics());
         refreshCalculatedChannelStats(channel);
-        refreshVideoRisingScores(channel);
         refreshChannelCategories(channel);
 
         return new ChannelDataSyncResult(channel, videoRepository.findByChannelId(channel.getId()));
@@ -100,7 +100,7 @@ public class YoutubeChannelDataSyncService {
     }
 
     private void upsertChannelStats(Channel channel, YoutubeDataChannelResponse.Statistics statistics) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
         Long subscriberCount = statistics == null ? null : toLong(statistics.subscriberCount());
         Long totalViewCount = statistics == null ? null : toLong(statistics.viewCount());
         Long totalVideoCount = statistics == null ? null : toLong(statistics.videoCount());
@@ -186,15 +186,13 @@ public class YoutubeChannelDataSyncService {
             ChannelStats channelStats,
             YoutubeDataChannelResponse.Statistics channelStatistics
     ) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
         YoutubeDataVideoResponse.Statistics statistics = item.statistics();
         Long viewCount = statistics == null ? null : toLong(statistics.viewCount());
         Long likeCount = statistics == null ? null : toLong(statistics.likeCount());
         Long commentCount = statistics == null ? null : toLong(statistics.commentCount());
         Double vph = calculateViewsPerHour(viewCount, video.getPublishedAt(), now);
         Double outlierScore = calculateOutlierScore(viewCount, channelStats, channelStatistics);
-        Double engagementRate = calculateEngagementRate(likeCount, commentCount, viewCount);
-        Double risingScore = calculateRisingScore(engagementRate, channelStats.getAvgEngagementRate(), outlierScore);
 
         videoStatsRepository.findByVideoId(video.getId())
                 .ifPresentOrElse(
@@ -204,7 +202,7 @@ public class YoutubeChannelDataSyncService {
                                 commentCount,
                                 vph,
                                 outlierScore,
-                                risingScore,
+                                null,
                                 now
                         ),
                         () -> videoStatsRepository.save(VideoStats.builder()
@@ -214,7 +212,7 @@ public class YoutubeChannelDataSyncService {
                                 .commentCount(commentCount)
                                 .vph(vph)
                                 .outlierScore(outlierScore)
-                                .risingScore(risingScore)
+                                .risingScore(null)
                                 .collectedAt(now)
                                 .build())
                 );
@@ -256,7 +254,7 @@ public class YoutubeChannelDataSyncService {
 
         List<Video> videos = videoRepository.findByChannelId(channel.getId());
         if (videos.isEmpty()) {
-            channelStats.updateCalculatedMetrics(0, 0.0, 0.0, 0.0, LocalDateTime.now());
+            channelStats.updateCalculatedMetrics(0, 0.0, 0.0, 0.0, LocalDateTime.now(ZoneOffset.UTC));
             return;
         }
 
@@ -265,35 +263,35 @@ public class YoutubeChannelDataSyncService {
                 ).stream()
                 .collect(Collectors.toMap(videoStats -> videoStats.getVideo().getId(), Function.identity()));
 
-        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now(ZoneOffset.UTC).minusDays(30);
         int recentUploadCount30d = (int) videos.stream()
                 .filter(video -> video.getPublishedAt() != null && !video.getPublishedAt().isBefore(thirtyDaysAgo))
                 .count();
 
         List<Video> recentVideos = videos.stream()
+                .filter(video -> video.getPublishedAt() != null && !video.getPublishedAt().isBefore(thirtyDaysAgo))
                 .sorted(Comparator.comparing(Video::getPublishedAt, Comparator.nullsLast(Comparator.reverseOrder())))
-                .limit(RECENT_VIDEO_SAMPLE_SIZE)
                 .toList();
 
-        double avgViewsRecentN = recentVideos.stream()
-                .map(Video::getId)
-                .map(videoStatsMap::get)
-                .filter(videoStats -> videoStats != null && videoStats.getViewCount() != null)
-                .mapToLong(VideoStats::getViewCount)
-                .average()
-                .orElse(0.0);
+        long totalViews = 0;
+        long totalLikes = 0;
+        long totalComments = 0;
+        for (Video video : recentVideos) {
+            VideoStats videoStats = videoStatsMap.get(video.getId());
+            if (videoStats == null) {
+                continue;
+            }
+            totalViews += defaultLong(videoStats.getViewCount());
+            totalLikes += defaultLong(videoStats.getLikeCount());
+            totalComments += defaultLong(videoStats.getCommentCount());
+        }
 
-        double avgEngagementRateRecentN = recentVideos.stream()
-                .map(Video::getId)
-                .map(videoStatsMap::get)
-                .filter(videoStats -> videoStats != null)
-                .mapToDouble(videoStats -> AnalyticsCalculator.engagementRate(
-                        videoStats.getLikeCount(),
-                        videoStats.getCommentCount(),
-                        videoStats.getViewCount()
-                ))
-                .average()
-                .orElse(0.0);
+        double avgViewsRecentN = recentVideos.isEmpty()
+                ? 0.0
+                : round((double) totalViews / recentVideos.size(), 2);
+        double avgEngagementRateRecentN = totalViews > 0
+                ? round(((double) (totalLikes + totalComments) / totalViews) * 100.0, 2)
+                : 0.0;
 
         double avgOutlierScoreRecentExcludingTop5Pct =
                 calculateAverageOutlierScoreRecentExcludingTop5Pct(recentVideos, videoStatsMap, channelStats);
@@ -303,7 +301,7 @@ public class YoutubeChannelDataSyncService {
                 avgViewsRecentN,
                 avgEngagementRateRecentN,
                 avgOutlierScoreRecentExcludingTop5Pct,
-                LocalDateTime.now()
+                LocalDateTime.now(ZoneOffset.UTC)
         );
     }
 
@@ -325,7 +323,7 @@ public class YoutubeChannelDataSyncService {
                 ).stream()
                 .collect(Collectors.toMap(videoStats -> videoStats.getVideo().getId(), Function.identity()));
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
         for (Video video : videos) {
             VideoStats videoStats = videoStatsMap.get(video.getId());
             if (videoStats == null) {
@@ -466,7 +464,7 @@ public class YoutubeChannelDataSyncService {
         if (!StringUtils.hasText(publishedAt)) {
             return null;
         }
-        return OffsetDateTime.parse(publishedAt).toLocalDateTime();
+        return OffsetDateTime.parse(publishedAt).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime();
     }
 
     private Integer parseDurationSeconds(YoutubeDataVideoResponse.ContentDetails contentDetails) {
@@ -540,10 +538,8 @@ public class YoutubeChannelDataSyncService {
             ChannelStats channelStats
     ) {
         List<Double> outlierScores = recentVideos.stream()
-                .map(Video::getId)
-                .map(videoStatsMap::get)
-                .filter(videoStats -> videoStats != null)
-                .map(videoStats -> calculateOutlierScore(videoStats.getViewCount(), channelStats, null))
+                .map(video -> videoStatsMap.get(video.getId()))
+                .map(videoStats -> calculateOutlierScore(videoStats == null ? 0L : videoStats.getViewCount(), channelStats, null))
                 .filter(Objects::nonNull)
                 .sorted(Comparator.reverseOrder())
                 .toList();

--- a/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
+++ b/src/main/java/com/example/inflace/domain/video/controller/VideoApi.java
@@ -28,7 +28,7 @@ public interface VideoApi {
                     "조회수, 좋아요, 댓글, 공유수, CTR, 참여율, 신규 유입률, VPH 등 주요 지표를 반환합니다. <br>" +
                     "DB에 데이터가 없을 경우 YouTube Analytics API를 호출하여 저장 후 반환합니다."
     )
-    @ApiErrorDefines(ErrorDefine.VIDEO_NOT_FOUND)
+    @ApiErrorDefines({ErrorDefine.VIDEO_NOT_FOUND, ErrorDefine.VIDEO_STATS_NOT_FOUND, ErrorDefine.ANALYTICS_DATA_NOT_FOUND, ErrorDefine.AUTH_FORBIDDEN})
     BaseResponse<VideoStatsResponse> getVideoStats(@PathVariable("videoId") Long videoId);
 
     @Operation(

--- a/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
+++ b/src/main/java/com/example/inflace/domain/video/domain/VideoStats.java
@@ -51,25 +51,25 @@ public class VideoStats extends BaseTimeEntity {
     public VideoStats(Video video, Long viewCount, Long likeCount, Long commentCount,
                       Double vph, Double outlierScore, Double risingScore, LocalDateTime collectedAt) {
         this.video = video;
-        this.viewCount = viewCount;
-        this.likeCount = likeCount;
-        this.commentCount = commentCount;
-        this.vph = vph;
-        this.outlierScore = outlierScore;
+        this.viewCount = viewCount == null ? 0L : viewCount;
+        this.likeCount = likeCount == null ? 0L : likeCount;
+        this.commentCount = commentCount == null ? 0L : commentCount;
+        this.vph = vph == null ? 0.0 : vph;
+        this.outlierScore = outlierScore == null ? 0.0 : outlierScore;
         this.risingScore = risingScore;
-        this.collectedAt = collectedAt;
+        this.collectedAt = collectedAt == null ? LocalDateTime.now() : collectedAt;
     }
 
     public void update(Long viewCount, Long likeCount, Long commentCount,
                        Double vph, Double outlierScore, Double risingScore,
                        LocalDateTime collectedAt) {
-        this.viewCount = viewCount;
-        this.likeCount = likeCount;
-        this.commentCount = commentCount;
-        this.vph = vph;
-        this.outlierScore = outlierScore;
+        this.viewCount = viewCount == null ? 0L : viewCount;
+        this.likeCount = likeCount == null ? 0L : likeCount;
+        this.commentCount = commentCount == null ? 0L : commentCount;
+        this.vph = vph == null ? 0.0 : vph;
+        this.outlierScore = outlierScore == null ? 0.0 : outlierScore;
         this.risingScore = risingScore;
-        this.collectedAt = collectedAt;
+        this.collectedAt = collectedAt == null ? LocalDateTime.now() : collectedAt;
     }
 
     public void update(Long viewCount, Long likeCount, Long commentCount, LocalDateTime collectedAt) {

--- a/src/main/java/com/example/inflace/domain/video/service/VideoService.java
+++ b/src/main/java/com/example/inflace/domain/video/service/VideoService.java
@@ -62,7 +62,9 @@ public class VideoService {
 
         VideoStats videoStats = videoStatsRepository.findByVideoId(videoId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.VIDEO_STATS_NOT_FOUND));
-        VideoAnalytics videoAnalytics = videoAnalyticsRepository.findByVideoId(videoId).orElse(null);
+        VideoAnalytics videoAnalytics = videoAnalyticsRepository.findByVideoId(videoId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.ANALYTICS_DATA_NOT_FOUND));
+        validateVideoStatsAnalytics(videoAnalytics);
 
         return VideoStatsResponse.from(videoStats, videoAnalytics, 0L, 0L);
     }
@@ -127,6 +129,15 @@ public class VideoService {
     private void validateVideoOwnership(Video video, UUID userId) {
         if (!video.getChannel().getUser().getId().equals(userId)) {
             throw new ApiException(ErrorDefine.AUTH_FORBIDDEN);
+        }
+    }
+
+    private void validateVideoStatsAnalytics(VideoAnalytics analytics) {
+        if (analytics.getShareCount() == null
+                || analytics.getSubscribersGained() == null
+                || analytics.getCtr() == null
+                || analytics.getUnsubscribedViewCount() == null) {
+            throw new ApiException(ErrorDefine.ANALYTICS_DATA_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -36,6 +36,7 @@ public enum ErrorDefine {
     CHANNEL_ANALYTICS_NOT_FOUND("CHANNEL_ANALYTICS_404", HttpStatus.NOT_FOUND, "Not Found: Channel Analytics not found"),
     CHANNEL_SYNC_COOLDOWN("CHANNEL_429_COOLDOWN", HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests: Channel sync is currently on cooldown"),
     CHANNEL_INSIGHT_REQUIRES_MIN_VIDEO_COUNT("CHANNEL_INSIGHT_400", HttpStatus.BAD_REQUEST, "Bad Request: At least 50 videos are required for channel insight"),
+    ANALYTICS_DATA_NOT_FOUND("ANALYTICS_404", HttpStatus.NOT_FOUND, "Not Found: Analytics data not found"),
 
     //ETC
     YOUTUBE_API_ERROR("YOUTUBE_500", HttpStatus.INTERNAL_SERVER_ERROR, "YouTube API Error");


### PR DESCRIPTION
##  Issue
closed #138 

---

## comment
채널 연동시 예외처리를 강화하였습니다
- stats을 채울때 null제약조건에 맞춰 0을 추가하는 로직을 추가하였습니다
- subscriberStatus와 같이 데이터가 부족하여 값을 불러오지 못해 db에 null로추가된 api의 경우 ANALYTICS_404 에러를 반환하게 하였습니다
- 채널 소유주 검증이 빠져있던 api에 채널 소유주 검증을 추가하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data integrity by applying default values for null numeric fields instead of accepting null inputs.
  * Standardized timestamp handling to UTC across data collection operations for consistency.

* **Security & Access Control**
  * Enhanced permission validation to ensure users can only access their own channel and video analytics.
  * Added stricter authentication checks on analytics and statistics endpoints.

* **Error Handling**
  * Expanded error definitions across API endpoints for better error reporting.
  * Introduced ANALYTICS_DATA_NOT_FOUND error code for clearer feedback when analytics data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/inflace-4th-server/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->