### PR TITLE
feat: 채널 PPL 영상 목록 정렬 기준 DB 통일 및 LIKE_COUNT 추가 -> dev

### DIFF
--- a/src/main/java/com/example/inflace/domain/brandcollaboration/dto/request/ChannelBrandHistorySearchCondition.java
+++ b/src/main/java/com/example/inflace/domain/brandcollaboration/dto/request/ChannelBrandHistorySearchCondition.java
@@ -20,7 +20,7 @@ public record ChannelBrandHistorySearchCondition(
         @Schema(description = "영상 카테고리 ID", example = "26")
         String categoryId,
 
-        @Schema(description = "정렬 기준", allowableValues = {"LATEST", "VIEW_COUNT"}, defaultValue = "LATEST")
+        @Schema(description = "정렬 기준", allowableValues = {"LATEST", "VIEW_COUNT", "LIKE_COUNT"}, defaultValue = "LATEST")
         String sortCriteria,
 
         @Schema(description = "정렬 방향", allowableValues = {"DESC"}, defaultValue = "DESC")

--- a/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
+++ b/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
@@ -85,7 +85,8 @@ public class ChannelBrandHistoryService {
                 condition.videoFormatEnum(),
                 true,
                 dbCursor,
-                condition.pageSize()
+                condition.pageSize(),
+                parseCategoryId(condition.categoryId())
         );
 
         ChannelVideoSliceResult result = videoQueryRepository.findChannelVideos(channelOpt.get().getId(), request);
@@ -108,13 +109,10 @@ public class ChannelBrandHistoryService {
         Map<Integer, String> categoryTitleMap = buildCategoryTitleMapFromDbVideos(videoMap.values());
         Map<String, String> aliasToNameMap = collectAliasToNameMap(videoMap.values());
 
-        Integer parsedCategoryId = parseCategoryId(condition.categoryId());
-
         List<ChannelBrandHistoryVideoResponse> content = result.videos().stream()
                 .map(item -> {
                     Video video = videoMap.get(item.videoId());
                     if (video == null) return null;
-                    if (parsedCategoryId != null && !parsedCategoryId.equals(video.getCategoryId())) return null;
                     String categoryName = video.getCategoryId() != null
                             ? categoryTitleMap.get(video.getCategoryId()) : null;
                     String format = Boolean.TRUE.equals(item.isShort()) ? FORMAT_SHORT_FORM : FORMAT_LONG_FORM;
@@ -218,6 +216,7 @@ public class ChannelBrandHistoryService {
         Set<String> candidates = videos.stream()
                 .flatMap(v -> descriptionTokens(v.getDescription()))
                 .filter(StringUtils::hasText)
+                .map(token -> token.toLowerCase(Locale.ROOT))
                 .collect(Collectors.toSet());
         return brandService.resolveAliasToNameMap(candidates);
     }

--- a/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
+++ b/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
@@ -106,12 +106,15 @@ public class ChannelBrandHistoryService {
                 .collect(Collectors.toMap(Video::getId, v -> v));
 
         Map<Integer, String> categoryTitleMap = buildCategoryTitleMapFromDbVideos(videoMap.values());
-        Map<String, String> aliasToNameMap = collectAliasToNameMapFromDbVideos(videoMap.values());
+        Map<String, String> aliasToNameMap = collectAliasToNameMap(videoMap.values());
+
+        Integer parsedCategoryId = parseCategoryId(condition.categoryId());
 
         List<ChannelBrandHistoryVideoResponse> content = result.videos().stream()
                 .map(item -> {
                     Video video = videoMap.get(item.videoId());
                     if (video == null) return null;
+                    if (parsedCategoryId != null && !parsedCategoryId.equals(video.getCategoryId())) return null;
                     String categoryName = video.getCategoryId() != null
                             ? categoryTitleMap.get(video.getCategoryId()) : null;
                     String format = Boolean.TRUE.equals(item.isShort()) ? FORMAT_SHORT_FORM : FORMAT_LONG_FORM;
@@ -208,12 +211,10 @@ public class ChannelBrandHistoryService {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
-        if (categoryIds.isEmpty()) return Map.of();
-        return youtubeCategoryRepository.findByYoutubeCategoryIdIn(categoryIds).stream()
-                .collect(Collectors.toMap(c -> c.getYoutubeCategoryId(), c -> c.getTitle()));
+        return resolveCategoryTitleMap(categoryIds);
     }
 
-    private Map<String, String> collectAliasToNameMapFromDbVideos(Collection<Video> videos) {
+    private Map<String, String> collectAliasToNameMap(Collection<Video> videos) {
         Set<String> candidates = videos.stream()
                 .flatMap(v -> descriptionTokens(v.getDescription()))
                 .filter(StringUtils::hasText)
@@ -235,6 +236,15 @@ public class ChannelBrandHistoryService {
         try {
             return OffsetDateTime.parse(rfc3339).toLocalDate();
         } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Integer parseCategoryId(String categoryId) {
+        if (!StringUtils.hasText(categoryId)) return null;
+        try {
+            return Integer.parseInt(categoryId);
+        } catch (NumberFormatException e) {
             return null;
         }
     }
@@ -263,14 +273,12 @@ public class ChannelBrandHistoryService {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+        return resolveCategoryTitleMap(categoryIds);
+    }
 
-        if (categoryIds.isEmpty()) {
-            return Map.of();
-        }
-
-        return youtubeCategoryRepository
-                .findByYoutubeCategoryIdIn(categoryIds)
-                .stream()
+    private Map<Integer, String> resolveCategoryTitleMap(List<Integer> categoryIds) {
+        if (categoryIds.isEmpty()) return Map.of();
+        return youtubeCategoryRepository.findByYoutubeCategoryIdIn(categoryIds).stream()
                 .collect(Collectors.toMap(c -> c.getYoutubeCategoryId(), c -> c.getTitle()));
     }
 

--- a/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
+++ b/src/main/java/com/example/inflace/domain/brandcollaboration/service/ChannelBrandHistoryService.java
@@ -1,14 +1,23 @@
 package com.example.inflace.domain.brandcollaboration.service;
 
 import com.example.inflace.domain.brand.service.BrandService;
+import com.example.inflace.domain.channel.domain.Channel;
+import com.example.inflace.domain.channel.dto.ChannelVideoSliceResult;
 import com.example.inflace.domain.channel.dto.request.ChannelVideoFormat;
+import com.example.inflace.domain.channel.dto.request.ChannelVideoSort;
+import com.example.inflace.domain.channel.dto.request.ChannelVideosRequest;
+import com.example.inflace.domain.channel.dto.response.ChannelVideosResponse;
 import com.example.inflace.domain.channel.dto.response.YoutubeDataChannelResponse;
+import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.channel.service.insight.InfluencerInsightScoreCalculator;
 import com.example.inflace.domain.youtubecategory.repository.YoutubeCategoryRepository;
 import com.example.inflace.domain.brandcollaboration.dto.request.ChannelBrandHistorySearchCondition;
 import com.example.inflace.domain.brandcollaboration.dto.response.ChannelBrandHistoryAnalysisResponse;
 import com.example.inflace.domain.brandcollaboration.dto.response.ChannelBrandHistoryVideoResponse;
+import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.dto.YoutubeDataVideoResponse;
+import com.example.inflace.domain.video.repository.VideoQueryRepository;
+import com.example.inflace.domain.video.repository.VideoRepository;
 import com.example.inflace.global.client.YoutubeDataApiClient;
 import com.example.inflace.global.client.YoutubeSearchApiClient;
 import com.example.inflace.global.client.YoutubeSearchApiClient.YoutubeSearchListResponse;
@@ -18,14 +27,20 @@ import com.example.inflace.global.response.CursorSliceResponse;
 import com.example.inflace.global.response.CustomSort;
 import com.example.inflace.global.util.AnalyticsCalculator;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,55 +66,90 @@ public class ChannelBrandHistoryService {
     private final YoutubeCategoryRepository youtubeCategoryRepository;
     private final BrandService brandService;
     private final InfluencerInsightScoreCalculator scoreCalculator;
+    private final ChannelRepository channelRepository;
+    private final VideoQueryRepository videoQueryRepository;
+    private final VideoRepository videoRepository;
 
     public CursorSliceResponse<ChannelBrandHistoryVideoResponse> search(String channelId, ChannelBrandHistorySearchCondition condition) {
-        String youtubePageToken = decodePageToken(condition.cursor(), condition.sortCriteriaValue(), condition.sortOrder().name());
-
-        YoutubeSearchListResponse searchResponse = youtubeSearchApiClient.search(
-                null,
-                youtubePageToken,
-                condition.youtubeOrder(),
-                null,
-                condition.categoryId(),
-                null,
-                null,
-                condition.pageSize(),
-                condition.startDate(),
-                condition.endDate(),
-                channelId
-        );
-
-        if (searchResponse == null || searchResponse.items() == null || searchResponse.items().isEmpty()) {
+        Optional<Channel> channelOpt = channelRepository.findByYoutubeChannelId(channelId);
+        if (channelOpt.isEmpty()) {
             return emptyResponse(condition);
         }
 
-        List<String> videoIds = searchResponse.items().stream()
-                .map(item -> item.id().videoId())
-                .filter(StringUtils::hasText)
-                .toList();
+        String dbCursor = decodePageToken(condition.cursor(), condition.sortCriteriaValue(), condition.sortOrder().name());
+        ChannelVideosRequest request = new ChannelVideosRequest(
+                null,
+                parseRfc3339ToLocalDate(condition.startDate()),
+                parseRfc3339ToLocalDate(condition.endDate()),
+                toChannelVideoSort(condition.sortCriteriaValue()),
+                condition.videoFormatEnum(),
+                true,
+                dbCursor,
+                condition.pageSize()
+        );
 
-        List<YoutubeDataVideoResponse.Item> videoItems = youtubeDataApiClient.getYoutubeVideos(videoIds, VIDEO_PARTS);
-        List<YoutubeDataVideoResponse.Item> filtered = applyVideoFormatFilter(videoItems, condition.videoFormatEnum());
+        ChannelVideoSliceResult result = videoQueryRepository.findChannelVideos(channelOpt.get().getId(), request);
 
-        if (filtered.isEmpty()) {
-            String nextCursor = encodeNextCursor(searchResponse.nextPageToken(), condition.sortCriteriaValue(), condition.sortOrder().name());
+        if (result.videos().isEmpty()) {
+            String nextCursor = encodeNextCursor(result.nextCursor(), condition.sortCriteriaValue(), condition.sortOrder().name());
             return new CursorSliceResponse<>(
                     List.of(),
-                    new CursorSliceResponse.PageInfo(condition.pageSize(), 0, nextCursor, nextCursor != null),
+                    new CursorSliceResponse.PageInfo(condition.pageSize(), 0, nextCursor, result.hasNext()),
                     CustomSort.of(true, condition.sortCriteriaValue(), condition.sortOrder().name())
             );
         }
 
-        Map<Integer, String> categoryTitleMap = buildCategoryTitleMap(filtered);
-        Map<String, String> aliasToNameMap = collectAliasToNameMap(filtered);
-        List<ChannelBrandHistoryVideoResponse> content = buildContent(filtered, categoryTitleMap, aliasToNameMap);
+        List<Long> dbVideoIds = result.videos().stream()
+                .map(ChannelVideosResponse.ChannelVideoItem::videoId)
+                .toList();
+        Map<Long, Video> videoMap = videoRepository.findAllById(dbVideoIds).stream()
+                .collect(Collectors.toMap(Video::getId, v -> v));
 
-        String nextCursor = encodeNextCursor(searchResponse.nextPageToken(), condition.sortCriteriaValue(), condition.sortOrder().name());
+        Map<Integer, String> categoryTitleMap = buildCategoryTitleMapFromDbVideos(videoMap.values());
+        Map<String, String> aliasToNameMap = collectAliasToNameMapFromDbVideos(videoMap.values());
+
+        List<ChannelBrandHistoryVideoResponse> content = result.videos().stream()
+                .map(item -> {
+                    Video video = videoMap.get(item.videoId());
+                    if (video == null) return null;
+                    String categoryName = video.getCategoryId() != null
+                            ? categoryTitleMap.get(video.getCategoryId()) : null;
+                    String format = Boolean.TRUE.equals(item.isShort()) ? FORMAT_SHORT_FORM : FORMAT_LONG_FORM;
+                    List<String> brands = extractBrandsFromDescription(video.getDescription(), aliasToNameMap);
+                    String publishedAt = item.publishedAt() != null
+                            ? item.publishedAt().atOffset(ZoneOffset.UTC)
+                                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                            : null;
+                    return new ChannelBrandHistoryVideoResponse(
+                            video.getYoutubeVideoId(),
+                            item.title(),
+                            item.thumbnailUrl(),
+                            publishedAt,
+                            item.viewCount() != null ? item.viewCount() : 0L,
+                            item.likeCount() != null ? item.likeCount() : 0L,
+                            item.commentCount() != null ? item.commentCount() : 0L,
+                            format,
+                            categoryName,
+                            brands
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        String nextCursor = encodeNextCursor(result.nextCursor(), condition.sortCriteriaValue(), condition.sortOrder().name());
         return new CursorSliceResponse<>(
                 content,
-                new CursorSliceResponse.PageInfo(condition.pageSize(), content.size(), nextCursor, nextCursor != null),
+                new CursorSliceResponse.PageInfo(condition.pageSize(), content.size(), nextCursor, result.hasNext()),
                 CustomSort.of(true, condition.sortCriteriaValue(), condition.sortOrder().name())
         );
+    }
+
+    private ChannelVideoSort toChannelVideoSort(String sortCriteria) {
+        return switch (sortCriteria) {
+            case "VIEW_COUNT" -> ChannelVideoSort.VIEWS;
+            case "LIKE_COUNT" -> ChannelVideoSort.LIKES;
+            default -> ChannelVideoSort.LATEST;
+        };
     }
 
     // https://developers.google.com/youtube/v3/docs/search/list
@@ -152,6 +202,43 @@ public class ChannelBrandHistoryService {
         );
     }
 
+    private Map<Integer, String> buildCategoryTitleMapFromDbVideos(Collection<Video> videos) {
+        List<Integer> categoryIds = videos.stream()
+                .map(Video::getCategoryId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (categoryIds.isEmpty()) return Map.of();
+        return youtubeCategoryRepository.findByYoutubeCategoryIdIn(categoryIds).stream()
+                .collect(Collectors.toMap(c -> c.getYoutubeCategoryId(), c -> c.getTitle()));
+    }
+
+    private Map<String, String> collectAliasToNameMapFromDbVideos(Collection<Video> videos) {
+        Set<String> candidates = videos.stream()
+                .flatMap(v -> descriptionTokens(v.getDescription()))
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+        return brandService.resolveAliasToNameMap(candidates);
+    }
+
+    private List<String> extractBrandsFromDescription(String description, Map<String, String> aliasToNameMap) {
+        return descriptionTokens(description)
+                .filter(StringUtils::hasText)
+                .map(token -> aliasToNameMap.get(token.toLowerCase(Locale.ROOT)))
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private LocalDate parseRfc3339ToLocalDate(String rfc3339) {
+        if (!StringUtils.hasText(rfc3339)) return null;
+        try {
+            return OffsetDateTime.parse(rfc3339).toLocalDate();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private List<YoutubeDataVideoResponse.Item> applyVideoFormatFilter(
             List<YoutubeDataVideoResponse.Item> items,
             ChannelVideoFormat format
@@ -185,54 +272,6 @@ public class ChannelBrandHistoryService {
                 .findByYoutubeCategoryIdIn(categoryIds)
                 .stream()
                 .collect(Collectors.toMap(c -> c.getYoutubeCategoryId(), c -> c.getTitle()));
-    }
-
-    private Map<String, String> collectAliasToNameMap(List<YoutubeDataVideoResponse.Item> items) {
-        Set<String> candidates = items.stream()
-                .filter(item -> item.snippet() != null)
-                .flatMap(item -> descriptionTokens(item.snippet().description()))
-                .filter(StringUtils::hasText)
-                .collect(Collectors.toSet());
-        return brandService.resolveAliasToNameMap(candidates);
-    }
-
-    private List<ChannelBrandHistoryVideoResponse> buildContent(
-            List<YoutubeDataVideoResponse.Item> items,
-            Map<Integer, String> categoryTitleMap,
-            Map<String, String> aliasToNameMap
-    ) {
-        return items.stream()
-                .map(item -> {
-                    String categoryName = resolveCategoryName(item, categoryTitleMap);
-                    String videoFormat = resolveVideoFormat(item);
-                    List<String> brands = extractBrands(item, aliasToNameMap);
-
-                    return new ChannelBrandHistoryVideoResponse(
-                            item.id(),
-                            item.snippet() != null ? item.snippet().title() : null,
-                            item.snippet() != null && item.snippet().thumbnails() != null
-                                    && item.snippet().thumbnails().high() != null
-                                    ? item.snippet().thumbnails().high().url() : null,
-                            item.snippet() != null ? item.snippet().publishedAt() : null,
-                            parseLong(item.statistics() != null ? item.statistics().viewCount() : null),
-                            parseLong(item.statistics() != null ? item.statistics().likeCount() : null),
-                            parseLong(item.statistics() != null ? item.statistics().commentCount() : null),
-                            videoFormat,
-                            categoryName,
-                            brands
-                    );
-                })
-                .toList();
-    }
-
-    private List<String> extractBrands(YoutubeDataVideoResponse.Item item, Map<String, String> aliasToNameMap) {
-        if (item.snippet() == null) return List.of();
-        return descriptionTokens(item.snippet().description())
-                .filter(StringUtils::hasText)
-                .map(token -> aliasToNameMap.get(token.toLowerCase(Locale.ROOT)))
-                .filter(Objects::nonNull)
-                .distinct()
-                .toList();
     }
 
     private Stream<String> descriptionTokens(String description) {
@@ -328,18 +367,6 @@ public class ChannelBrandHistoryService {
         }
         int seconds = (int) AnalyticsCalculator.parseIso8601Duration(item.contentDetails().duration());
         return seconds <= SHORTS_MAX_DURATION_SECONDS ? FORMAT_SHORT_FORM : FORMAT_LONG_FORM;
-    }
-
-    private String resolveCategoryName(YoutubeDataVideoResponse.Item item, Map<Integer, String> categoryTitleMap) {
-        if (item.snippet() == null || !StringUtils.hasText(item.snippet().categoryId())) {
-            return null;
-        }
-        try {
-            int categoryId = Integer.parseInt(item.snippet().categoryId());
-            return categoryTitleMap.get(categoryId);
-        } catch (NumberFormatException e) {
-            return null;
-        }
     }
 
     private String decodePageToken(String cursor, String expectedSortCriteria, String expectedSortOrder) {

--- a/src/main/java/com/example/inflace/domain/channel/dto/request/ChannelVideosRequest.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/request/ChannelVideosRequest.java
@@ -12,7 +12,8 @@ public record ChannelVideosRequest(
         ChannelVideoFormat format,
         Boolean isAd,
         String cursor,
-        Integer size
+        Integer size,
+        Integer categoryId
 ) {
     private static final int DEFAULT_SIZE = 12;
     private static final int MAX_SIZE = 50;

--- a/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/ChannelRepository.java
@@ -10,4 +10,5 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
     boolean existsByUser_Id(UUID userId);
     Optional<Channel> findByUser_Id(UUID userId);
     Optional<Channel> findByUser_IdAndYoutubeChannelId(UUID userId, String youtubeChannelId);
+    Optional<Channel> findByYoutubeChannelId(String youtubeChannelId);
 }

--- a/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/ChannelService.java
@@ -300,7 +300,8 @@ public class ChannelService {
                 parsedFormat,
                 isAd,
                 cursor,
-                size
+                size,
+                null
         );
         ChannelVideoSliceResult result = videoQueryRepository.findChannelVideos(channelId, request);
 

--- a/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
+++ b/src/main/java/com/example/inflace/domain/video/repository/VideoQueryRepositoryImpl.java
@@ -49,6 +49,10 @@ public class VideoQueryRepositoryImpl implements VideoQueryRepository {
             predicate.and(video.isAdvertisement.eq(request.isAd()));
         }
 
+        if (request.categoryId() != null) {
+            predicate.and(video.categoryId.eq(request.categoryId()));
+        }
+
         BooleanExpression publishedAtCondition = buildPublishedAtCondition(request, video);
         if (publishedAtCondition != null) {
             predicate.and(publishedAtCondition);


### PR DESCRIPTION
##  Issue
#144 

---

## comment
- `GET /api/v1/brand-collaborations/channels/{channelId}` sortCriteria에 `LIKE_COUNT` 추가
- 기존 코드베이스에 맞춰 `search()` 데이터 소스를 YouTube Search API → DB(`VideoQueryRepository`)로 전환

## 비고
- 요청/응답 스펙 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채널 브랜드 이력 정렬에 "좋아요 수(LIKE_COUNT)" 옵션이 추가되었습니다.
  * 채널 동영상 조회 시 카테고리 필터를 지정할 수 있습니다.

* **개선 사항**
  * 채널 동영상 검색 및 응답 형식이 개선되어 조회 결과의 일관성과 안정성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/inflace-4th-server/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->