### PR TITLE
In 300 회원 탈퇴 탈퇴 사유 기재

### DIFF
--- a/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
+++ b/src/main/java/com/example/inflace/domain/auth/util/GoogleAccessTokenStore.java
@@ -50,6 +50,11 @@ public class GoogleAccessTokenStore {
         return authTokenRedisRepository.get(googleRefreshTokenKey(googleId));
     }
 
+    public void deleteTokens(String googleId) {
+        authTokenRedisRepository.delete(googleAccessTokenKey(googleId));
+        authTokenRedisRepository.delete(googleRefreshTokenKey(googleId));
+    }
+
     private String googleAccessTokenKey(String googleId) {
         return GOOGLE_ACCESS_TOKEN_PREFIX + googleId;
     }

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -1,6 +1,7 @@
 package com.example.inflace.domain.user.application;
 
 import com.example.inflace.domain.auth.presentation.dto.UserDetailsResponse;
+import com.example.inflace.domain.auth.service.AuthTokenRedisService;
 import com.example.inflace.domain.channel.domain.Channel;
 import com.example.inflace.domain.channel.domain.ChannelCategory;
 import com.example.inflace.domain.channel.domain.ChannelStats;
@@ -55,6 +56,7 @@ public class UserService {
     private final ChannelStatsRepository channelStatsRepository;
     private final VideoRepository videoRepository;
     private final S3ImageStorageService imageStorageService;
+    private final AuthTokenRedisService authTokenRedisService;
 
     @Transactional
     public UserRegistrationResult registerIfNotExists(String sub, String name, String email, String profileImage, Plan plan) {
@@ -73,7 +75,9 @@ public class UserService {
     @Transactional
     public void withdraw() {
         UUID userId = SecurityUtils.getAuthenticatedUserId();
-        userCommandRepository.deleteUser(userId);
+        userCommandRepository.softDeleteUser(userId);
+        authTokenRedisService.deleteRefreshToken(userId);
+        SecurityUtils.clear();
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -27,6 +27,7 @@ import com.example.inflace.domain.user.presentation.ProfileImageUploadUrlRespons
 import com.example.inflace.domain.user.presentation.UserChannelMainResponse;
 import com.example.inflace.domain.user.presentation.UserPreferenceUpdateRequest;
 import com.example.inflace.domain.user.presentation.UserProfileResponse;
+import com.example.inflace.domain.user.presentation.WithdrawRequest;
 import com.example.inflace.domain.user.presentation.YoutubeLinkedResponse;
 import com.example.inflace.domain.video.domain.Video;
 import com.example.inflace.domain.video.repository.VideoRepository;
@@ -73,9 +74,10 @@ public class UserService {
     }
 
     @Transactional
-    public void withdraw() {
+    public void withdraw(WithdrawRequest request) {
         UUID userId = SecurityUtils.getAuthenticatedUserId();
         userCommandRepository.softDeleteUser(userId);
+        userCommandRepository.insertWithdrawalRecord(userId, request.reason(), request.detail());
         authTokenRedisService.deleteRefreshToken(userId);
         SecurityUtils.clear();
     }

--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.example.inflace.domain.user.application;
 
 import com.example.inflace.domain.auth.presentation.dto.UserDetailsResponse;
 import com.example.inflace.domain.auth.service.AuthTokenRedisService;
+import com.example.inflace.domain.auth.util.GoogleAccessTokenStore;
 import com.example.inflace.domain.channel.domain.Channel;
 import com.example.inflace.domain.channel.domain.ChannelCategory;
 import com.example.inflace.domain.channel.domain.ChannelStats;
@@ -35,6 +36,8 @@ import com.example.inflace.global.annotation.ReadOnlyTransactional;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.security.util.SecurityUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import com.example.inflace.infra.aws.s3.S3ImageStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,6 +61,7 @@ public class UserService {
     private final VideoRepository videoRepository;
     private final S3ImageStorageService imageStorageService;
     private final AuthTokenRedisService authTokenRedisService;
+    private final GoogleAccessTokenStore googleAccessTokenStore;
 
     @Transactional
     public UserRegistrationResult registerIfNotExists(String sub, String name, String email, String profileImage, Plan plan) {
@@ -76,10 +80,21 @@ public class UserService {
     @Transactional
     public void withdraw(WithdrawRequest request) {
         UUID userId = SecurityUtils.getAuthenticatedUserId();
+        User user = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
         userCommandRepository.softDeleteUser(userId);
         userCommandRepository.insertWithdrawalRecord(userId, request.reason(), request.detail());
-        authTokenRedisService.deleteRefreshToken(userId);
-        SecurityUtils.clear();
+
+        String providerId = user.getProviderId();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                authTokenRedisService.deleteRefreshToken(userId);
+                googleAccessTokenStore.deleteTokens(providerId);
+                SecurityUtils.clear();
+            }
+        });
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/com/example/inflace/domain/user/application/UserWithdrawalPurgeScheduler.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserWithdrawalPurgeScheduler.java
@@ -1,0 +1,30 @@
+package com.example.inflace.domain.user.application;
+
+import com.example.inflace.domain.user.infra.UserCommandRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawalPurgeScheduler {
+
+    private final UserCommandRepository userCommandRepository;
+
+    @Value("${user.withdrawal.purge.retention-days:30}")
+    private int retentionDays;
+
+    @Transactional
+    @Scheduled(cron = "${user.withdrawal.purge.cron}", zone = "Asia/Seoul")
+    public void purge() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(retentionDays);
+        int deleted = userCommandRepository.purgeWithdrawnUsers(threshold);
+        log.info("userWithdrawalPurge completed. deleted={}, threshold={}", deleted, threshold);
+    }
+}

--- a/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.UUID;
 
@@ -24,6 +25,7 @@ import java.util.UUID;
                 columnNames = "provider_id"
         )
 )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends SoftDeleteTimeEntity {

--- a/src/main/java/com/example/inflace/domain/user/domain/enums/WithdrawalReason.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/enums/WithdrawalReason.java
@@ -1,0 +1,10 @@
+package com.example.inflace.domain.user.domain.enums;
+
+public enum WithdrawalReason {
+    YOUTUBE_LINK_INCONVENIENT,      // 유튜브 채널 연동이 불편해요
+    INSUFFICIENT_ANALYSIS_FEATURES, // 필요한 분석 기능이 부족해요
+    EXPENSIVE_PLAN,                 // 구독 플랜 가격이 부담돼요
+    DASHBOARD_DIFFICULT,            // 대시보드 사용이 어려워요
+    SWITCHING_TO_OTHER_TOOL,        // 다른 마케팅/채널 분석 툴로 이동해요
+    TEMPORARY_USE                   // 일시적으로 사용
+}

--- a/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -62,6 +63,14 @@ public class UserCommandRepository {
                 "INSERT INTO user_withdrawal (user_id, reason, detail, created_at) VALUES (?, ?, ?, now())",
                 userId, reason.name(), detail
         );
+    }
+
+    public int purgeWithdrawnUsers(LocalDateTime threshold) {
+        return jdbcTemplate.update("""
+                DELETE FROM users
+                WHERE deleted_at IS NOT NULL
+                  AND deleted_at < ?
+                """, threshold);
     }
 
     public void insertUserTypes(UUID userId, List<UserRole> roles) {

--- a/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
@@ -3,6 +3,8 @@ package com.example.inflace.domain.user.infra;
 import com.example.inflace.domain.user.domain.enums.Need;
 import com.example.inflace.domain.user.domain.enums.Plan;
 import com.example.inflace.domain.user.domain.enums.UserRole;
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.util.UuidV7Generator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -28,6 +30,7 @@ public class UserCommandRepository {
         on conflict (provider_id)
         do update set
             provider_id = excluded.provider_id,
+            deleted_at = null,
             updated_at = now()
         returning user_id, (xmax = 0) as inserted
     """, newUserId, sub, name, email, profileImage, plan.name());
@@ -40,6 +43,17 @@ public class UserCommandRepository {
 
     public void deleteUser(UUID userId) {
         jdbcTemplate.update("delete from users where user_id = ?", userId);
+    }
+
+    public void softDeleteUser(UUID userId) {
+        int affected = jdbcTemplate.update("""
+                UPDATE users
+                SET deleted_at = now(), updated_at = now()
+                WHERE user_id = ? AND deleted_at IS NULL
+                """, userId);
+        if (affected == 0) {
+            throw new ApiException(ErrorDefine.USER_NOT_FOUND);
+        }
     }
 
     public void insertUserTypes(UUID userId, List<UserRole> roles) {

--- a/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
@@ -3,6 +3,7 @@ package com.example.inflace.domain.user.infra;
 import com.example.inflace.domain.user.domain.enums.Need;
 import com.example.inflace.domain.user.domain.enums.Plan;
 import com.example.inflace.domain.user.domain.enums.UserRole;
+import com.example.inflace.domain.user.domain.enums.WithdrawalReason;
 import com.example.inflace.global.exception.ApiException;
 import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.util.UuidV7Generator;
@@ -54,6 +55,13 @@ public class UserCommandRepository {
         if (affected == 0) {
             throw new ApiException(ErrorDefine.USER_NOT_FOUND);
         }
+    }
+
+    public void insertWithdrawalRecord(UUID userId, WithdrawalReason reason, String detail) {
+        jdbcTemplate.update(
+                "INSERT INTO user_withdrawal (user_id, reason, detail, created_at) VALUES (?, ?, ?, now())",
+                userId, reason.name(), detail
+        );
     }
 
     public void insertUserTypes(UUID userId, List<UserRole> roles) {

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
@@ -61,8 +61,8 @@ public interface UserApi {
 
     @Operation(
             summary = "회원 탈퇴",
-            description = "현재 로그인된 유저를 영구 삭제합니다 (복구 불가)"
+            description = "탈퇴 사유를 기재하고 현재 로그인된 유저를 탈퇴 처리합니다."
     )
     @ApiErrorDefines(ErrorDefine.USER_NOT_FOUND)
-    ResponseEntity<BaseResponse<Void>> withdraw();
+    ResponseEntity<BaseResponse<Void>> withdraw(@RequestBody WithdrawRequest request);
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -76,8 +76,8 @@ public class UserController implements UserApi {
 
     @Override
     @DeleteMapping("/delete")
-    public ResponseEntity<BaseResponse<Void>> withdraw() {
-        userService.withdraw();
+    public ResponseEntity<BaseResponse<Void>> withdraw(@Valid @RequestBody WithdrawRequest request) {
+        userService.withdraw(request);
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, authCookieUtils.buildDeleteRefreshTokenCookie().toString())
                 .body(new BaseResponse<>(null));

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -1,9 +1,11 @@
 package com.example.inflace.domain.user.presentation;
 
+import com.example.inflace.domain.auth.util.AuthCookieUtils;
 import com.example.inflace.domain.user.application.UserService;
 import com.example.inflace.global.response.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserApi {
 
     private final UserService userService;
+    private final AuthCookieUtils authCookieUtils;
 
     @Override
     @PostMapping("/onboarding")
@@ -75,6 +78,8 @@ public class UserController implements UserApi {
     @DeleteMapping("/delete")
     public ResponseEntity<BaseResponse<Void>> withdraw() {
         userService.withdraw();
-        return ResponseEntity.ok(new BaseResponse<>(null));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, authCookieUtils.buildDeleteRefreshTokenCookie().toString())
+                .body(new BaseResponse<>(null));
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/WithdrawRequest.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/WithdrawRequest.java
@@ -1,0 +1,10 @@
+package com.example.inflace.domain.user.presentation;
+
+import com.example.inflace.domain.user.domain.enums.WithdrawalReason;
+import jakarta.validation.constraints.NotNull;
+
+public record WithdrawRequest(
+        @NotNull WithdrawalReason reason,
+        String detail
+) {
+}

--- a/src/main/java/com/example/inflace/global/config/SchedulingConfig.java
+++ b/src/main/java/com/example/inflace/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.example.inflace.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,3 +28,9 @@ cors:
     origins:
       - https://www.inflace.site
       - http://localhost:3000
+
+user:
+  withdrawal:
+    purge:
+      retention-days: ${USER_WITHDRAWAL_PURGE_RETENTION_DAYS}
+      cron: ${USER_WITHDRAWAL_PURGE_CRON}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,6 +30,12 @@ channel:
   sync:
     cooldown-millis: 3600
 
+user:
+  withdrawal:
+    purge:
+      retention-days: 30
+      cron: "0 0 2 * * *"
+
 cors:
   allowed:
     origins:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,3 +28,9 @@ cors:
   allowed:
     origins:
       - https://www.inflace.site
+
+user:
+  withdrawal:
+    purge:
+      retention-days: ${USER_WITHDRAWAL_PURGE_RETENTION_DAYS}
+      cron: ${USER_WITHDRAWAL_PURGE_CRON}

--- a/src/main/resources/db/migration/V20260523000000__create_index_users_deleted_at.sql
+++ b/src/main/resources/db/migration/V20260523000000__create_index_users_deleted_at.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users (deleted_at);

--- a/src/main/resources/db/migration/V20260525000000__create_table_user_withdrawal.sql
+++ b/src/main/resources/db/migration/V20260525000000__create_table_user_withdrawal.sql
@@ -5,5 +5,5 @@ CREATE TABLE IF NOT EXISTS user_withdrawal (
     detail     TEXT,
     created_at TIMESTAMP    NOT NULL,
     CONSTRAINT fk_user_withdrawal_user
-        FOREIGN KEY (user_id) REFERENCES users (user_id)
+        FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/migration/V20260525000000__create_table_user_withdrawal.sql
+++ b/src/main/resources/db/migration/V20260525000000__create_table_user_withdrawal.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS user_withdrawal (
+    id         BIGSERIAL PRIMARY KEY,
+    user_id    UUID         NOT NULL,
+    reason     VARCHAR(50)  NOT NULL,
+    detail     TEXT,
+    created_at TIMESTAMP    NOT NULL,
+    CONSTRAINT fk_user_withdrawal_user
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+);


### PR DESCRIPTION
##  Issue
#146 

---

## comment
- User 엔티티에 @SQLRestriction("deleted_at IS NULL") 추가 — 탈퇴 회원 자동 필터링
- 탈퇴 API DELETE /api/v1/user/delete soft-delete로 전환
- 탈퇴 시 Redis refresh token 삭제 + refresh token 쿠키 만료 처리
- Flyway 마이그레이션 2개 추가 (idx_users_deleted_at, user_withdrawal 테이블)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회원 탈퇴 시 사유 선택 및 상세 입력 가능
  * 탈퇴 이력 자동 기록
  * 탈퇴 후 자동 로그아웃 및 관련 계정 연동 정보 정리
* **운영/유지보수**
  * 탈퇴된 계정에 대한 장기 보관 후 자동 정리(스케줄러) 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/inflace-4th-server/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->