### PR TITLE
In 326 이메일 알람 설정 api

### DIFF
--- a/src/main/java/com/example/inflace/domain/user/application/UserService.java
+++ b/src/main/java/com/example/inflace/domain/user/application/UserService.java
@@ -12,11 +12,14 @@ import com.example.inflace.domain.channel.repository.ChannelCategoryRepository;
 import com.example.inflace.domain.channel.repository.ChannelRepository;
 import com.example.inflace.domain.channel.repository.ChannelStatsRepository;
 import com.example.inflace.domain.user.domain.entity.User;
+import com.example.inflace.domain.user.domain.entity.UserAlarm;
 import com.example.inflace.domain.user.domain.entity.UserNeed;
 import com.example.inflace.domain.user.domain.entity.UserType;
+import com.example.inflace.domain.user.domain.enums.AlarmType;
 import com.example.inflace.domain.user.domain.enums.Need;
 import com.example.inflace.domain.user.domain.enums.Plan;
 import com.example.inflace.domain.user.domain.enums.UserRole;
+import com.example.inflace.domain.user.infra.UserAlarmRepository;
 import com.example.inflace.domain.user.infra.UserCommandRepository;
 import com.example.inflace.domain.user.infra.UserNeedRepository;
 import com.example.inflace.domain.user.infra.UserReadRepository;
@@ -26,6 +29,11 @@ import com.example.inflace.domain.user.presentation.OnboardingRequest;
 import com.example.inflace.domain.user.presentation.ProfileImageUpdateRequest;
 import com.example.inflace.domain.user.presentation.ProfileImageUploadUrlRequest;
 import com.example.inflace.domain.user.presentation.ProfileImageUploadUrlResponse;
+import com.example.inflace.domain.user.presentation.UserAlarmEmailUpdateRequest;
+import com.example.inflace.domain.user.presentation.UserAlarmEmailUpdateResponse;
+import com.example.inflace.domain.user.presentation.UserAlarmUpdateRequest;
+import com.example.inflace.domain.user.presentation.UserAlarmUpdateResponse;
+import com.example.inflace.domain.user.presentation.UserAlarmsResponse;
 import com.example.inflace.domain.user.presentation.UserChannelMainResponse;
 import com.example.inflace.domain.user.presentation.GetUserMeResponse;
 import com.example.inflace.domain.user.presentation.UserPreferenceUpdateRequest;
@@ -45,8 +53,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +68,7 @@ public class UserService {
 
     private final UserReadRepository userReadRepository;
     private final UserCommandRepository userCommandRepository;
+    private final UserAlarmRepository userAlarmRepository;
     private final UserTypeRepository userTypeRepository;
     private final UserNeedRepository userNeedRepository;
     private final ChannelRepository channelRepository;
@@ -215,6 +229,50 @@ public class UserService {
         userCommandRepository.insertNeeds(userId, request.needs());
     }
 
+    @Transactional
+    public UserAlarmsResponse getAlarms() {
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        User user = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+        List<UserAlarm> alarms = getOrCreateUserAlarms(user);
+
+        return new UserAlarmsResponse(
+                user.getAlarmEmail(),
+                alarms.stream()
+                        .map(alarm -> new UserAlarmsResponse.AlarmInfo(
+                                alarm.getAlarmType(),
+                                alarm.isEnabled()
+                        ))
+                        .toList()
+        );
+    }
+
+    @Transactional
+    public UserAlarmUpdateResponse updateAlarm(UserAlarmUpdateRequest request) {
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        User user = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        UserAlarm userAlarm = userAlarmRepository.findByUser_IdAndAlarmType(userId, request.alarmType())
+                .orElseGet(() -> userAlarmRepository.save(
+                        UserAlarm.of(user, request.alarmType(), request.enabled())
+                ));
+        userAlarm.updateEnabled(request.enabled());
+
+        return new UserAlarmUpdateResponse(userAlarm.getAlarmType(), userAlarm.isEnabled());
+    }
+
+    @Transactional
+    public UserAlarmEmailUpdateResponse updateAlarmEmail(UserAlarmEmailUpdateRequest request) {
+        UUID userId = SecurityUtils.getAuthenticatedUserId();
+        User user = userReadRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        user.updateAlarmEmail(request.alarmEmail());
+
+        return new UserAlarmEmailUpdateResponse(user.getAlarmEmail());
+    }
+
     private List<UserRole> getUserRoles(UUID userId) {
         return userTypeRepository.findAllByUser_Id(userId).stream()
                 .map(UserType::getRole)
@@ -224,6 +282,26 @@ public class UserService {
     private List<Need> getUserNeeds(UUID userId) {
         return userNeedRepository.findAllByUser_Id(userId).stream()
                 .map(UserNeed::getNeed)
+                .toList();
+    }
+
+    private List<UserAlarm> getOrCreateUserAlarms(User user) {
+        List<UserAlarm> alarms = userAlarmRepository.findAllByUser_Id(user.getId());
+        Map<AlarmType, UserAlarm> alarmByType = alarms.stream()
+                .collect(Collectors.toMap(UserAlarm::getAlarmType, Function.identity()));
+
+        List<UserAlarm> missingAlarms = Arrays.stream(AlarmType.values())
+                .filter(alarmType -> !alarmByType.containsKey(alarmType))
+                .map(alarmType -> UserAlarm.of(user, alarmType, false))
+                .toList();
+
+        if (!missingAlarms.isEmpty()) {
+            userAlarmRepository.saveAll(missingAlarms);
+            missingAlarms.forEach(alarm -> alarmByType.put(alarm.getAlarmType(), alarm));
+        }
+
+        return alarmByType.values().stream()
+                .sorted(Comparator.comparingInt(alarm -> alarm.getAlarmType().ordinal()))
                 .toList();
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/entity/User.java
@@ -41,6 +41,9 @@ public class User extends SoftDeleteTimeEntity {
 
     private String email;
 
+    @Column(name = "alarm_email")
+    private String alarmEmail;
+
     @Column(name = "provider_id", nullable = false, unique = true)
     private String providerId;
 
@@ -52,6 +55,7 @@ public class User extends SoftDeleteTimeEntity {
             String name,
             String profileImage,
             String email,
+            String alarmEmail,
             String providerId,
             Plan plan
     ) {
@@ -61,6 +65,7 @@ public class User extends SoftDeleteTimeEntity {
         user.name = name;
         user.profileImage = profileImage;
         user.email = email;
+        user.alarmEmail = alarmEmail;
         user.providerId = providerId;
         user.plan = plan;
 
@@ -69,5 +74,9 @@ public class User extends SoftDeleteTimeEntity {
 
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void updateAlarmEmail(String alarmEmail) {
+        this.alarmEmail = alarmEmail;
     }
 }

--- a/src/main/java/com/example/inflace/domain/user/domain/entity/UserAlarm.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/entity/UserAlarm.java
@@ -1,0 +1,62 @@
+package com.example.inflace.domain.user.domain.entity;
+
+import com.example.inflace.domain.user.domain.enums.AlarmType;
+import com.example.inflace.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "user_alarm",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_alarm_user_alarm_type",
+                columnNames = {"user_id", "alarm_type"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAlarm extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_alarm_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "alarm_type", nullable = false, length = 50)
+    private AlarmType alarmType;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    public static UserAlarm of(User user, AlarmType alarmType, boolean enabled) {
+        UserAlarm userAlarm = new UserAlarm();
+
+        userAlarm.user = user;
+        userAlarm.alarmType = alarmType;
+        userAlarm.enabled = enabled;
+
+        return userAlarm;
+    }
+
+    public void updateEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/example/inflace/domain/user/domain/enums/AlarmType.java
+++ b/src/main/java/com/example/inflace/domain/user/domain/enums/AlarmType.java
@@ -1,0 +1,7 @@
+package com.example.inflace.domain.user.domain.enums;
+
+public enum AlarmType {
+    PAYMENT,
+    FEATURE_UPDATE,
+    EVENT_BENEFIT
+}

--- a/src/main/java/com/example/inflace/domain/user/infra/UserAlarmRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserAlarmRepository.java
@@ -1,0 +1,16 @@
+package com.example.inflace.domain.user.infra;
+
+import com.example.inflace.domain.user.domain.entity.UserAlarm;
+import com.example.inflace.domain.user.domain.enums.AlarmType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
+
+    List<UserAlarm> findAllByUser_Id(UUID userId);
+
+    Optional<UserAlarm> findByUser_IdAndAlarmType(UUID userId, AlarmType alarmType);
+}

--- a/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
+++ b/src/main/java/com/example/inflace/domain/user/infra/UserCommandRepository.java
@@ -27,15 +27,15 @@ public class UserCommandRepository {
         UUID newUserId = UuidV7Generator.next();
 
         Map<String, Object> result = jdbcTemplate.queryForMap("""
-        insert into users (user_id, provider_id, name, email, profile_image, plan, created_at, updated_at)
-        values (?, ?, ?, ?, ?, ?, now(), now())
+        insert into users (user_id, provider_id, name, email, alarm_email, profile_image, plan, created_at, updated_at)
+        values (?, ?, ?, ?, ?, ?, ?, now(), now())
         on conflict (provider_id)
         do update set
             provider_id = excluded.provider_id,
             deleted_at = null,
             updated_at = now()
         returning user_id, (xmax = 0) as inserted
-    """, newUserId, sub, name, email, profileImage, plan.name());
+    """, newUserId, sub, name, email, email, profileImage, plan.name());
 
         UUID userId = (UUID) result.get("user_id");
         boolean isNew = (Boolean) result.get("inserted");

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmEmailUpdateRequest.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmEmailUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.example.inflace.domain.user.presentation;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserAlarmEmailUpdateRequest(
+        @NotBlank @Email String alarmEmail
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmEmailUpdateResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmEmailUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.example.inflace.domain.user.presentation;
+
+public record UserAlarmEmailUpdateResponse(
+        String alarmEmail
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmUpdateRequest.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.example.inflace.domain.user.presentation;
+
+import com.example.inflace.domain.user.domain.enums.AlarmType;
+import jakarta.validation.constraints.NotNull;
+
+public record UserAlarmUpdateRequest(
+        @NotNull AlarmType alarmType,
+        @NotNull Boolean enabled
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmUpdateResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmUpdateResponse.java
@@ -1,0 +1,9 @@
+package com.example.inflace.domain.user.presentation;
+
+import com.example.inflace.domain.user.domain.enums.AlarmType;
+
+public record UserAlarmUpdateResponse(
+        AlarmType alarmType,
+        boolean enabled
+) {
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmsResponse.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserAlarmsResponse.java
@@ -1,0 +1,16 @@
+package com.example.inflace.domain.user.presentation;
+
+import com.example.inflace.domain.user.domain.enums.AlarmType;
+
+import java.util.List;
+
+public record UserAlarmsResponse(
+        String alarmEmail,
+        List<AlarmInfo> alarms
+) {
+    public record AlarmInfo(
+            AlarmType alarmType,
+            boolean enabled
+    ) {
+    }
+}

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserApi.java
@@ -72,4 +72,25 @@ public interface UserApi {
     )
     @ApiErrorDefines(ErrorDefine.USER_NOT_FOUND)
     ResponseEntity<BaseResponse<Void>> withdraw(@RequestBody WithdrawRequest request);
+
+    @Operation(
+            summary = "마이페이지 알림 설정 조회",
+            description = "현재 로그인한 유저의 알림 수신 이메일과 알림 종류별 수신 여부를 조회합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.USER_NOT_FOUND})
+    BaseResponse<UserAlarmsResponse> getAlarms();
+
+    @Operation(
+            summary = "마이페이지 알림 수신 여부 수정",
+            description = "현재 로그인한 유저의 특정 알림 종류 수신 여부를 수정합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.USER_NOT_FOUND})
+    BaseResponse<UserAlarmUpdateResponse> updateAlarm(@RequestBody UserAlarmUpdateRequest request);
+
+    @Operation(
+            summary = "마이페이지 알림 수신 이메일 수정",
+            description = "현재 로그인한 유저의 알림 수신 이메일을 수정합니다."
+    )
+    @ApiErrorDefines({ErrorDefine.AUTH_FORBIDDEN, ErrorDefine.USER_NOT_FOUND})
+    BaseResponse<UserAlarmEmailUpdateResponse> updateAlarmEmail(@RequestBody UserAlarmEmailUpdateRequest request);
 }

--- a/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/inflace/domain/user/presentation/UserController.java
@@ -89,4 +89,26 @@ public class UserController implements UserApi {
                 .header(HttpHeaders.SET_COOKIE, authCookieUtils.buildDeleteRefreshTokenCookie().toString())
                 .body(new BaseResponse<>(null));
     }
+
+    @Override
+    @GetMapping("/alarms")
+    public BaseResponse<UserAlarmsResponse> getAlarms() {
+        return new BaseResponse<>(userService.getAlarms());
+    }
+
+    @Override
+    @PutMapping("/alarms")
+    public BaseResponse<UserAlarmUpdateResponse> updateAlarm(
+            @Valid @RequestBody UserAlarmUpdateRequest request
+    ) {
+        return new BaseResponse<>(userService.updateAlarm(request));
+    }
+
+    @Override
+    @PutMapping("/alarms/email")
+    public BaseResponse<UserAlarmEmailUpdateResponse> updateAlarmEmail(
+            @Valid @RequestBody UserAlarmEmailUpdateRequest request
+    ) {
+        return new BaseResponse<>(userService.updateAlarmEmail(request));
+    }
 }

--- a/src/main/resources/db/migration/V20260603213959__alter_table_users_add_column_alarm_email.sql
+++ b/src/main/resources/db/migration/V20260603213959__alter_table_users_add_column_alarm_email.sql
@@ -1,0 +1,2 @@
+alter table users
+    add column alarm_email varchar(255);

--- a/src/main/resources/db/migration/V20260603214136__update_users_set_alarm_email.sql
+++ b/src/main/resources/db/migration/V20260603214136__update_users_set_alarm_email.sql
@@ -1,0 +1,3 @@
+update users
+set alarm_email = email
+where alarm_email is null;

--- a/src/main/resources/db/migration/V20260603214304__create_table_user_alarm.sql
+++ b/src/main/resources/db/migration/V20260603214304__create_table_user_alarm.sql
@@ -1,0 +1,14 @@
+create table user_alarm (
+    user_alarm_id bigserial primary key,
+    user_id uuid not null,
+    alarm_type varchar(50) not null,
+    enabled boolean not null default true,
+    created_at timestamp not null,
+    updated_at timestamp not null,
+
+    constraint fk_user_alarm_user
+        foreign key (user_id) references users(user_id),
+
+    constraint uk_user_alarm_user_alarm_type
+        unique (user_id, alarm_type)
+);

--- a/src/main/resources/db/migration/V20260603214304__create_table_user_alarm.sql
+++ b/src/main/resources/db/migration/V20260603214304__create_table_user_alarm.sql
@@ -2,7 +2,7 @@ create table user_alarm (
     user_alarm_id bigserial primary key,
     user_id uuid not null,
     alarm_type varchar(50) not null,
-    enabled boolean not null default true,
+    enabled boolean not null default false,
     created_at timestamp not null,
     updated_at timestamp not null,
 


### PR DESCRIPTION
##  Issue
closed #167 

---

## comment
마이페이지 알람설정 api를 구현하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 설정 기능 추가: 사용자가 결제, 기능 업데이트, 이벤트 혜택 등 알림 타입별로 수신 여부를 관리할 수 있습니다.
  * 알림 수신 이메일 설정: 알림을 받을 이메일 주소를 변경할 수 있습니다.
  * 마이페이지에 알림 관리 API 추가: 알림 조회, 알림 활성화/비활성화, 이메일 업데이트 기능 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->