### PR TITLE
fix: 내부 예외 메시지 노출 차단

### DIFF
--- a/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
+++ b/src/main/java/com/example/inflace/global/exception/ErrorDefine.java
@@ -11,6 +11,7 @@ public enum ErrorDefine {
     INVALID_DATE_FORMAT("COMMON_400_DATE_FORMAT", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date format"),
     INVALID_DATE_RANGE("COMMON_400_DATE_RANGE", HttpStatus.BAD_REQUEST, "Bad Request: Invalid date range"),
     DUPLICATE_IDEMPOTENCY_REQUEST("COMMON_409_IDEMPOTENCY", HttpStatus.CONFLICT, "Conflict: Duplicate idempotency request"),
+    INTERNAL_SERVER_ERROR("500", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     AUTH_UNSUPPORTED_PROVIDER("AUTH_401", HttpStatus.BAD_REQUEST, "Bad Request: Unsupported OAuth Provider"),
     AUTHENTICATION_FAILED("AUTH_401_UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "Unauthorized: Authentication required"),
     INVALID_ACCESS_TOKEN("AUTH_401_ACCESS", HttpStatus.UNAUTHORIZED, "Unauthorized: Invalid access token"),

--- a/src/main/java/com/example/inflace/global/exception/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/example/inflace/global/exception/GlobalRestExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.inflace.global.exception;
 
 import com.example.inflace.global.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.concurrent.CompletionException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalRestExceptionHandler {
     @ExceptionHandler(value = {ApiException.class})
     public ResponseEntity<?> handleApiException(ApiException e) {
@@ -28,7 +30,8 @@ public class GlobalRestExceptionHandler {
 
     @ExceptionHandler(value = {Exception.class})
     public ResponseEntity<?> handleException(Exception e) {
-        return BaseResponse.toResponseEntity(e);
+        log.error("Unexpected server error", e);
+        return BaseResponse.toInternalServerErrorResponse();
     }
 
     @ExceptionHandler(CompletionException.class)
@@ -39,7 +42,8 @@ public class GlobalRestExceptionHandler {
             return BaseResponse.toResponseEntity(apiException);
         }
 
-        return BaseResponse.toResponseEntity(e);
+        log.error("Unexpected async server error", e);
+        return BaseResponse.toInternalServerErrorResponse();
     }
 
 }

--- a/src/main/java/com/example/inflace/global/exception/JSONConvertExceptionDTO.java
+++ b/src/main/java/com/example/inflace/global/exception/JSONConvertExceptionDTO.java
@@ -1,22 +1,10 @@
 package com.example.inflace.global.exception;
 
 import com.example.inflace.global.response.ExceptionResponse;
-import lombok.Getter;
 import org.springframework.http.converter.HttpMessageConversionException;
 
-import java.util.Optional;
-
-@Getter
 public class JSONConvertExceptionDTO extends ExceptionResponse {
-    private final String message;
-    private final String cause;
-
     public JSONConvertExceptionDTO(HttpMessageConversionException jsonException) {
         super(ErrorDefine.INVALID_ARGUMENT);
-
-        this.message = jsonException.getMessage();
-        this.cause = Optional.ofNullable(jsonException.getCause())
-                .map(Throwable::toString)
-                .orElse("Non-Throwable Cause");
     }
 }

--- a/src/main/java/com/example/inflace/global/filter/IdempotencyKeyFilter.java
+++ b/src/main/java/com/example/inflace/global/filter/IdempotencyKeyFilter.java
@@ -74,8 +74,7 @@ public class IdempotencyKeyFilter extends OncePerRequestFilter {
             apiFilterErrorResponseWriter.write(
                     request,
                     response,
-                    ErrorDefine.DUPLICATE_IDEMPOTENCY_REQUEST,
-                    ErrorDefine.DUPLICATE_IDEMPOTENCY_REQUEST.getMessage()
+                    ErrorDefine.DUPLICATE_IDEMPOTENCY_REQUEST
             );
             return;
         }

--- a/src/main/java/com/example/inflace/global/response/ApiFilterErrorResponseWriter.java
+++ b/src/main/java/com/example/inflace/global/response/ApiFilterErrorResponseWriter.java
@@ -23,8 +23,7 @@ public class ApiFilterErrorResponseWriter {
     public void write(
             HttpServletRequest request,
             HttpServletResponse response,
-            ErrorDefine errorDefine,
-            String message
+            ErrorDefine errorDefine
     ) throws IOException {
         CustomCorsHeaderConfigurer.setCorsHeader(request, response, corsAllowedOriginsProperties.getOrigins());
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
@@ -34,7 +33,7 @@ public class ApiFilterErrorResponseWriter {
         BaseResponse<Void> errorResponse = BaseResponse.<Void>builder()
                 .isSuccess(false)
                 .responseDto(null)
-                .error(new ExceptionResponse(errorDefine, message))
+                .error(new ExceptionResponse(errorDefine))
                 .build();
 
         objectMapper.writeValue(response.getWriter(), errorResponse);

--- a/src/main/java/com/example/inflace/global/response/BaseResponse.java
+++ b/src/main/java/com/example/inflace/global/response/BaseResponse.java
@@ -1,6 +1,7 @@
 package com.example.inflace.global.response;
 
 import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
 import com.example.inflace.global.exception.InvalidateArgumentExceptionDTO;
 import com.example.inflace.global.exception.JSONConvertExceptionDTO;
 import io.micrometer.common.lang.Nullable;
@@ -55,13 +56,13 @@ public class BaseResponse<T> {
                                 .build());
     }
 
-    public static ResponseEntity<Object> toResponseEntity(Exception e) {
+    public static ResponseEntity<Object> toInternalServerErrorResponse() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(
                         BaseResponse.builder()
                                 .isSuccess(false)
                                 .responseDto(null)
-                                .error(new ExceptionResponse(e))
+                                .error(new ExceptionResponse(ErrorDefine.INTERNAL_SERVER_ERROR))
                                 .build());
     }
 

--- a/src/main/java/com/example/inflace/global/response/ExceptionResponse.java
+++ b/src/main/java/com/example/inflace/global/response/ExceptionResponse.java
@@ -4,7 +4,6 @@ import com.example.inflace.global.exception.ErrorDefine;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @Builder
@@ -16,15 +15,5 @@ public class ExceptionResponse {
     public ExceptionResponse(ErrorDefine errorDefine) {
         this.code = errorDefine.getErrorCode();
         this.message = errorDefine.getMessage();
-    }
-
-    public ExceptionResponse(ErrorDefine errorDefine, String message) {
-        this.code = errorDefine.getErrorCode();
-        this.message = message != null ? message : errorDefine.getMessage();
-    }
-
-    public ExceptionResponse(Exception e) {
-        this.code = Integer.toString(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        this.message = e.getMessage();
     }
 }

--- a/src/main/java/com/example/inflace/global/security/custom/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/inflace/global/security/custom/CustomAccessDeniedHandler.java
@@ -23,15 +23,10 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException {
-        String message = accessDeniedException != null && accessDeniedException.getMessage() != null
-                ? accessDeniedException.getMessage()
-                : "Forbidden";
-
         apiFilterErrorResponseWriter.write(
                 request,
                 response,
-                ErrorDefine.AUTH_FORBIDDEN,
-                message
+                ErrorDefine.AUTH_FORBIDDEN
         );
     }
 }

--- a/src/main/java/com/example/inflace/global/security/custom/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/inflace/global/security/custom/CustomAuthenticationEntryPoint.java
@@ -25,18 +25,15 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             AuthenticationException authException
     ) throws IOException {
         ErrorDefine errorDefine = ErrorDefine.AUTHENTICATION_FAILED;
-        String message = ErrorDefine.AUTHENTICATION_FAILED.getMessage();
 
         if (authException instanceof JwtAuthenticationException jwtAuthenticationException) {
             errorDefine = jwtAuthenticationException.getError();
-            message = jwtAuthenticationException.getMessage();
         }
 
         apiFilterErrorResponseWriter.write(
                 request,
                 response,
-                errorDefine,
-                message
+                errorDefine
         );
     }
 }

--- a/src/test/java/com/example/inflace/global/response/ErrorResponseTest.java
+++ b/src/test/java/com/example/inflace/global/response/ErrorResponseTest.java
@@ -1,0 +1,58 @@
+package com.example.inflace.global.response;
+
+import com.example.inflace.global.exception.ApiException;
+import com.example.inflace.global.exception.ErrorDefine;
+import com.example.inflace.global.exception.GlobalRestExceptionHandler;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 예상하지_못한_예외의_내부_메시지는_응답에_노출하지_않는다() throws Exception {
+        Exception exception = new IllegalStateException("database password leaked");
+
+        ResponseEntity<?> response = new GlobalRestExceptionHandler().handleException(exception);
+        JsonNode body = objectMapper.valueToTree(response.getBody());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+        assertThat(body.at("/error/code").asText()).isEqualTo(ErrorDefine.INTERNAL_SERVER_ERROR.getErrorCode());
+        assertThat(body.at("/error/message").asText()).isEqualTo(ErrorDefine.INTERNAL_SERVER_ERROR.getMessage());
+        assertThat(body.toString()).doesNotContain("database password leaked");
+    }
+
+    @Test
+    void JSON_변환_예외의_메시지와_원인은_응답에_노출하지_않는다() {
+        HttpMessageConversionException exception = new HttpMessageConversionException(
+                "request body leaked",
+                new IllegalArgumentException("parser detail leaked")
+        );
+
+        ResponseEntity<?> response = BaseResponse.toResponseEntity(exception);
+        JsonNode body = objectMapper.valueToTree(response.getBody());
+
+        assertThat(body.at("/error/code").asText()).isEqualTo(ErrorDefine.INVALID_ARGUMENT.getErrorCode());
+        assertThat(body.at("/error/message").asText()).isEqualTo(ErrorDefine.INVALID_ARGUMENT.getMessage());
+        assertThat(body.toString())
+                .doesNotContain("request body leaked")
+                .doesNotContain("parser detail leaked")
+                .doesNotContain("cause");
+    }
+
+    @Test
+    void API_예외의_정의된_메시지는_응답에_유지한다() {
+        ResponseEntity<?> response = BaseResponse.toResponseEntity(new ApiException(ErrorDefine.USER_NOT_FOUND));
+        JsonNode body = objectMapper.valueToTree(response.getBody());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(body.at("/error/code").asText()).isEqualTo(ErrorDefine.USER_NOT_FOUND.getErrorCode());
+        assertThat(body.at("/error/message").asText()).isEqualTo(ErrorDefine.USER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
##  Issue
closed #328

---

## comment
- 예상하지 못한 서버 예외 응답을 `500 / Internal Server Error`로 고정했습니다.
- JSON 변환 및 인증·인가 필터 응답에서 내부 예외 메시지와 원인이 노출되지 않도록 변경했습니다.
- 정의된 API 오류 메시지는 기존대로 유지하고 회귀 테스트를 추가했습니다.

### 검증
- `./gradlew build -x test`: 통과
- 오류 응답 회귀 테스트 3개 격리 실행: 통과
- `./gradlew test`: 기존 `VideoServiceTest`, `AnalyticsCalculatorTest`의 현재 API 불일치 19건으로 `compileTestJava` 실패

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 예외 발생 시 민감한 내부 정보가 응답에 노출되지 않도록 개선했습니다.
  * 서버 오류 응답 처리를 일관되게 표준화했습니다.

* **테스트**
  * 오류 응답의 보안과 정합성을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->