### PR TITLE
in-334-모든-테이블의-외래키에-관한-인덱스-추가 -> develop

### DIFF
--- a/src/main/resources/db/migration/V20260610133400__create_index_audience_retention_video_id.sql
+++ b/src/main/resources/db/migration/V20260610133400__create_index_audience_retention_video_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_audience_retention_video_id
+    on audience_retention (video_id);

--- a/src/main/resources/db/migration/V20260610133401__create_index_batch_job_execution_job_instance_id.sql
+++ b/src/main/resources/db/migration/V20260610133401__create_index_batch_job_execution_job_instance_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_batch_job_execution_job_instance_id
+    on batch_job_execution (job_instance_id);

--- a/src/main/resources/db/migration/V20260610133402__create_index_batch_job_execution_params_job_execution_id.sql
+++ b/src/main/resources/db/migration/V20260610133402__create_index_batch_job_execution_params_job_execution_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_batch_job_execution_params_job_execution_id
+    on batch_job_execution_params (job_execution_id);

--- a/src/main/resources/db/migration/V20260610133403__create_index_batch_step_execution_job_execution_id.sql
+++ b/src/main/resources/db/migration/V20260610133403__create_index_batch_step_execution_job_execution_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_batch_step_execution_job_execution_id
+    on batch_step_execution (job_execution_id);

--- a/src/main/resources/db/migration/V20260610133404__create_index_channel_bookmark_user_id.sql
+++ b/src/main/resources/db/migration/V20260610133404__create_index_channel_bookmark_user_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_channel_bookmark_user_id
+    on channel_bookmark (user_id);

--- a/src/main/resources/db/migration/V20260610133405__create_index_channel_brand_brand_id.sql
+++ b/src/main/resources/db/migration/V20260610133405__create_index_channel_brand_brand_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_channel_brand_brand_id
+    on channel_brand (brand_id);

--- a/src/main/resources/db/migration/V20260610133406__create_index_channel_category_category_id.sql
+++ b/src/main/resources/db/migration/V20260610133406__create_index_channel_category_category_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_channel_category_category_id
+    on channel_category (category_id);

--- a/src/main/resources/db/migration/V20260610133407__create_index_user_need_user_id.sql
+++ b/src/main/resources/db/migration/V20260610133407__create_index_user_need_user_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_user_need_user_id
+    on user_need (user_id);

--- a/src/main/resources/db/migration/V20260610133408__create_index_user_withdrawal_user_id.sql
+++ b/src/main/resources/db/migration/V20260610133408__create_index_user_withdrawal_user_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_user_withdrawal_user_id
+    on user_withdrawal (user_id);

--- a/src/main/resources/db/migration/V20260610133409__create_index_video_channel_id.sql
+++ b/src/main/resources/db/migration/V20260610133409__create_index_video_channel_id.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_video_channel_id
+    on video (channel_id);


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
미확인

---

## comment
- 로컬 PostgreSQL의 외래키 컬럼 중 선두 컬럼 기준 커버 인덱스가 없는 10개 대상에 인덱스를 추가했습니다.
- 인덱스별로 Flyway 마이그레이션 스크립트를 분리했습니다.
- 로컬 DB 재검증 결과 외래키 커버 인덱스 누락은 0건입니다.

### 검증
- `python3 scripts/spec_lint.py`: 통과
- `python3 scripts/housekeeping.py`: 통과
- `./gradlew build -x test`: 통과
- `./gradlew test`: 기존 테스트 소스 컴파일 오류 19건으로 실패 (`VideoServiceTest`, `AnalyticsCalculatorTest`), 본 PR 변경과 무관

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 데이터베이스 조회 성능을 향상시키기 위해 다수의 테이블에 인덱스를 추가하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->