### PR TITLE
in-333-인플루언서-검색-pg-bigm-기반-gin-인덱스-추가 -> develop

### DIFF
--- a/docker/postgres-pgbigm/Dockerfile
+++ b/docker/postgres-pgbigm/Dockerfile
@@ -1,0 +1,20 @@
+FROM postgres:17
+
+ARG PGBIGM_REF=v1.2-20250903
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        libicu-dev \
+        postgresql-server-dev-17 \
+    && git clone --depth 1 --branch "${PGBIGM_REF}" https://github.com/pgbigm/pg_bigm.git /tmp/pg_bigm \
+    && make -C /tmp/pg_bigm USE_PGXS=1 \
+    && make -C /tmp/pg_bigm USE_PGXS=1 install \
+    && apt-get purge -y --auto-remove \
+        build-essential \
+        git \
+        libicu-dev \
+        postgresql-server-dev-17 \
+    && rm -rf /var/lib/apt/lists/* /tmp/pg_bigm

--- a/spring-boot-docker-compose.yml
+++ b/spring-boot-docker-compose.yml
@@ -2,9 +2,13 @@ version: "3.9" # Docker Compose 파일 버전
 
 services:
   postgres:
-    image: postgres:17
+    build:
+      context: .
+      dockerfile: docker/postgres-pgbigm/Dockerfile
+    image: inflace-postgres-pgbigm:17
     container_name: inflace-postgres-17
     restart: always
+    command: postgres -c shared_preload_libraries=pg_bigm
     environment:
       POSTGRES_USER: inflace
       POSTGRES_PASSWORD: password

--- a/src/main/java/com/example/inflace/domain/channel/repository/querydsl/impl/CustomInfluencerQueryRepositoryImpl.java
+++ b/src/main/java/com/example/inflace/domain/channel/repository/querydsl/impl/CustomInfluencerQueryRepositoryImpl.java
@@ -19,6 +19,8 @@ import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -270,7 +272,11 @@ public class CustomInfluencerQueryRepositoryImpl implements CustomInfluencerQuer
             return null;
         }
 
-        return new BooleanBuilder(channel.name.containsIgnoreCase(channelName));
+        StringExpression likePattern = Expressions.stringTemplate(
+                "cast(function('likequery', lower({0})) as string)",
+                channelName
+        );
+        return new BooleanBuilder(channel.name.lower().like(likePattern, '\\'));
     }
 
     private BooleanBuilder buildCategoryIdIn(List<Long> categoryIds) {

--- a/src/main/resources/db/migration/V20260610000000__create_pg_bigm_extension.sql
+++ b/src/main/resources/db/migration/V20260610000000__create_pg_bigm_extension.sql
@@ -1,0 +1,1 @@
+create extension if not exists pg_bigm;

--- a/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql
+++ b/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql
@@ -1,2 +1,6 @@
-create index concurrently if not exists idx_channel_lower_name_bigm
+create index if not exists idx_channel_lower_name_bigm
     on channel using gin (lower(name) gin_bigm_ops);
+
+-- 운영 환경에서 쓰기 차단을 피하려면 위 구문 대신 아래 인덱스를 수동으로 생성한다.
+-- create index concurrently if not exists idx_channel_lower_name_bigm
+--     on channel using gin (lower(name) gin_bigm_ops);

--- a/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql
+++ b/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql
@@ -1,0 +1,2 @@
+create index concurrently if not exists idx_channel_lower_name_bigm
+    on channel using gin (lower(name) gin_bigm_ops);

--- a/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql.conf
+++ b/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql.conf
+++ b/src/main/resources/db/migration/V20260610000001__create_channel_name_bigm_index.sql.conf
@@ -1,1 +1,0 @@
-executeInTransaction=false


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

---

## comment
- 로컬 PostgreSQL 이미지에 pg_bigm 확장을 구성했습니다.
- 채널명 lower(name) 표현식에 pg_bigm GIN 인덱스를 추가했습니다.
- 인플루언서 채널명 검색에 likequery 기반 부분 검색과 특수문자 이스케이프를 적용했습니다.
- 운영 환경에서 필요 시 concurrent 인덱스를 수동 생성할 수 있도록 SQL을 함께 표시했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채널 이름 검색 성능 개선을 위해 PostgreSQL pg_bigm 확장 통합
  * 향상된 패턴 매칭을 통한 더 정확한 검색 결과 제공

* **Chores**
  * Docker 환경 구성 업데이트로 새로운 검색 기능 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->