### PR TITLE
in-336-헬스체크-api-및-redis-service는-로깅되지-않도록-수정 -> develop

### DIFF
--- a/src/main/java/com/example/inflace/global/aop/LoggingAspect.java
+++ b/src/main/java/com/example/inflace/global/aop/LoggingAspect.java
@@ -18,12 +18,18 @@ import java.util.Map;
 @Slf4j
 public class LoggingAspect {
 
-    @Around("within(@org.springframework.web.bind.annotation.RestController *)")
+    @Around("""
+            within(@org.springframework.web.bind.annotation.RestController *)
+            && !within(com.example.inflace.global.controller.HealthCheckController)
+            """)
     public Object logControllerExecution(ProceedingJoinPoint joinPoint) throws Throwable {
         return logExecution(joinPoint, "controller");
     }
 
-    @Around("within(@org.springframework.stereotype.Service *)")
+    @Around("""
+            within(@org.springframework.stereotype.Service *)
+            && !within(com.example.inflace..*RedisService)
+            """)
     public Object logServiceExecution(ProceedingJoinPoint joinPoint) throws Throwable {
         return logExecution(joinPoint, "service");
     }

--- a/src/test/java/com/example/inflace/global/aop/LoggingAspectTest.java
+++ b/src/test/java/com/example/inflace/global/aop/LoggingAspectTest.java
@@ -1,12 +1,21 @@
 package com.example.inflace.global.aop;
 
+import com.example.inflace.domain.auth.service.AuthTokenRedisService;
+import com.example.inflace.global.controller.HealthCheckController;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.MDC;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -72,6 +81,74 @@ class LoggingAspectTest {
         }
     }
 
+    @Test
+    void 헬스_체크_컨트롤러는_로깅_대상에서_제외한다() throws NoSuchMethodException {
+        assertThat(matches(
+                aroundExpression("logControllerExecution"),
+                HealthCheckController.class,
+                "healthCheck",
+                String.class
+        )).isFalse();
+    }
+
+    @Test
+    void 일반_컨트롤러는_로깅_대상에_포함한다() throws NoSuchMethodException {
+        assertThat(matches(aroundExpression("logControllerExecution"), TestController.class, "getChannel"))
+                .isTrue();
+    }
+
+    @Test
+    void 레디스_서비스는_실행_로깅_대상에서_제외한다() throws NoSuchMethodException {
+        assertThat(matches(
+                aroundExpression("logServiceExecution"),
+                AuthTokenRedisService.class,
+                "saveLogoutAccessToken",
+                String.class,
+                long.class
+        ))
+                .isFalse();
+    }
+
+    @Test
+    void 레디스_서비스는_예외_로깅_대상에_포함한다() throws NoSuchMethodException {
+        assertThat(matches(
+                afterThrowingExpression("logServiceException"),
+                AuthTokenRedisService.class,
+                "saveLogoutAccessToken",
+                String.class,
+                long.class
+        ))
+                .isTrue();
+    }
+
+    @Test
+    void 일반_서비스는_로깅_대상에_포함한다() throws NoSuchMethodException {
+        assertThat(matches(aroundExpression("logServiceExecution"), TestService.class, "syncChannel"))
+                .isTrue();
+    }
+
+    private String aroundExpression(String methodName) throws NoSuchMethodException {
+        return LoggingAspect.class
+                .getMethod(methodName, ProceedingJoinPoint.class)
+                .getAnnotation(Around.class)
+                .value();
+    }
+
+    private String afterThrowingExpression(String methodName) throws NoSuchMethodException {
+        return LoggingAspect.class
+                .getMethod(methodName, org.aspectj.lang.JoinPoint.class, Throwable.class)
+                .getAnnotation(AfterThrowing.class)
+                .pointcut();
+    }
+
+    private boolean matches(String expression, Class<?> targetType, String methodName, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression(expression);
+        Method method = targetType.getMethod(methodName, parameterTypes);
+        return pointcut.matches(method, targetType);
+    }
+
     private ProceedingJoinPoint joinPoint(String methodName, Object result) {
         ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
         MethodSignature signature = mock(MethodSignature.class);
@@ -102,5 +179,19 @@ class LoggingAspectTest {
     }
 
     private static final class TestTarget {
+    }
+
+    @RestController
+    public static final class TestController {
+
+        public void getChannel() {
+        }
+    }
+
+    @Service
+    public static final class TestService {
+
+        public void syncChannel() {
+        }
     }
 }


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->

---

## comment
- 사용자 흐름 추적 로그에서 헬스 체크 API와 Redis 서비스의 정상 실행 로그를 제외했습니다.
- Redis 서비스 예외 로깅은 유지하고 포인트컷 대상 검증 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 어플리케이션 로깅 적용 범위 조정으로 특정 컴포넌트의 로깅 동작 최적화

* **Tests**
  * 로깅 포인트컷 매칭 검증 테스트 추가로 로깅 규칙 적용 정확성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->