### PR TITLE
in-341-분석-가능-채널-최소-영상-개수-10-개로-조정 -> develop

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/InfluencerApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/InfluencerApi.java
@@ -85,7 +85,7 @@ public interface InfluencerApi {
             description = """
                     특정 인플루언서 채널의 팬층, 콘텐츠, 활동, 롱폼/숏폼 지표를 종합 조회합니다.
                     
-                    - 영상이 50개 이상인 채널만 조회 가능합니다.
+                    - 영상이 10개 이상인 채널만 조회 가능합니다.
                     - 기본 채널 정보로 `channelName`, `categories`, `channelHandle`, `joinedAt`, `subscriberCount`를 함께 반환합니다.
                     - 로그인한 사용자의 즐겨찾기 여부(`bookmarked`)가 함께 내려갑니다.
                     - 이 API는 지표 조회 전용이며 OpenAI 요약 생성은 별도 API에서 수행합니다.

--- a/src/main/java/com/example/inflace/domain/channel/service/insight/InfluencerInsightQueryService.java
+++ b/src/main/java/com/example/inflace/domain/channel/service/insight/InfluencerInsightQueryService.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class InfluencerInsightQueryService {
 
-    private static final int MIN_VIDEO_COUNT_FOR_INSIGHT = 50;
+    private static final int MIN_VIDEO_COUNT_FOR_INSIGHT = 10;
     private static final int MAX_RECENT_VIDEO_DESCRIPTION_COUNT = 10;
 
     private final ChannelRepository channelRepository;


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
closed #341

---

## comment
<!-- 남길 코멘트 -->
- 인플루언서 인사이트 조회가 가능한 최소 영상 개수를 50개에서 10개로 조정했습니다.
- Swagger 설명을 실제 최소 영상 개수와 일치시켰습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 인플루언서 채널 인사이트 조회 시 필요한 최소 영상 수 요구사항을 50개에서 10개로 완화하여, 더 많은 인플루언서가 인사이트 기능을 이용할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->