### PR TITLE
in-342-인플루언서-검색-참여율-필터-0-이상으로-변경 -> develop

### DIFF
--- a/src/main/java/com/example/inflace/domain/channel/controller/InfluencerApi.java
+++ b/src/main/java/com/example/inflace/domain/channel/controller/InfluencerApi.java
@@ -26,7 +26,7 @@ public interface InfluencerApi {
                     - 로그인한 사용자의 즐겨찾기 여부(`bookmarked`)가 각 인플루언서 항목에 함께 내려갑니다.
                     - 기본 정렬 기준: `engagement_rate`
                     - 기본 정렬 방향: `DESC`
-                    - 기본 최소 참여율: `2.0`
+                    - 기본 최소 참여율: `0.0`
                     - 기본 페이지 크기: `9`
                     - `categoryIds`는 `/api/v1/youtube-categories`에서 내려준 `id` 값을 반복 전달합니다. 예: `?categoryIds=1&categoryIds=2`
                     - 다음 페이지 요청 시에는 이전 응답의 `nextCursor` 값을 `cursor`로 그대로 전달합니다.

--- a/src/main/java/com/example/inflace/domain/channel/dto/request/InfluencerSearchCondition.java
+++ b/src/main/java/com/example/inflace/domain/channel/dto/request/InfluencerSearchCondition.java
@@ -37,9 +37,9 @@ public record InfluencerSearchCondition(
         List<Long> categoryIds,
 
         @Schema(
-                description = "최소 참여율(%) 필터. 미입력 시 2.0",
-                defaultValue = "2.0",
-                example = "2.0"
+                description = "최소 참여율(%) 필터. 미입력 시 0.0",
+                defaultValue = "0.0",
+                example = "0.0"
         )
         Double engagementRateFrom,
 
@@ -106,7 +106,7 @@ public record InfluencerSearchCondition(
 
     public InfluencerSearchCondition {
         categoryIds = categoryIds == null ? List.of() : categoryIds;
-        engagementRateFrom = engagementRateFrom == null ? 2.0 : engagementRateFrom;
+        engagementRateFrom = engagementRateFrom == null ? 0.0 : engagementRateFrom;
         pageSize = pageSize == null ? DEFAULT_PAGE_SIZE : pageSize;
         sortOrder = sortOrder == null ? SortOrder.DESC : sortOrder;
         cursor = StringUtils.hasText(cursor) ? cursor : null;

--- a/src/test/java/com/example/inflace/domain/channel/dto/request/InfluencerSearchConditionTest.java
+++ b/src/test/java/com/example/inflace/domain/channel/dto/request/InfluencerSearchConditionTest.java
@@ -1,0 +1,30 @@
+package com.example.inflace.domain.channel.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InfluencerSearchConditionTest {
+
+    @Test
+    void defaultsMinimumEngagementRateToZero() {
+        InfluencerSearchCondition condition = new InfluencerSearchCondition(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThat(condition.engagementRateFrom()).isZero();
+    }
+}


### PR DESCRIPTION
##  Issue
<!-- closed #번호 -->
closed #342

---

## comment
<!-- 남길 코멘트 -->
- 인플루언서 검색의 기본 최소 참여율 필터를 2%에서 0%로 조정했습니다.
- API 설명을 실제 기본값과 일치시키고 회귀 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인플루언서 검색 필터의 최소 참여율 기본값이 2.0에서 0.0으로 수정되었습니다.

* **문서**
  * API 문서의 최소 참여율 기본값 관련 안내가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->